### PR TITLE
Make docker env optional and move it to docker folder

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,11 @@
+name: Verify Docker Build
+on: [push]
+
+jobs:
+  docker:
+    name: Verify that Docker can build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the Dockerfile
+        run: docker-compose build

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To run the generator locally, you have two options:
 2. **Docker Setup** (Recommended for Windows†):
    - [Clone] the repository and install [Docker and Docker compose](https://docs.docker.com/get-docker/).
    - Run `docker compose up` in the project root directory.
-     - To avoid running the make scripts when rebuilding, add `SKIP_MAKE_FILES=true` to the file `docker/.env`. This reduces build time if all target files and docs have already been created.
+     - To avoid running the make scripts when rebuilding, create the file `docker/.env` with contents `SKIP_MAKE_FILES=true`. This skips rebuilding target files and docs.
    - Visit [`http://localhost:5173/beta`](http://localhost:5173/beta).
 
 † Docker is recommended on Windows since you'll need `make` and a ideally Linux shell. You can alternatively [use in Cygwin](https://www.cygwin.com/), [install make](https://stackoverflow.com/a/73862277), or piece together what you need to run from the `Makefile` :)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ To run the generator locally, you have two options:
 2. **Docker Setup** (Recommended for Windows†):
    - [Clone] the repository and install [Docker and Docker compose](https://docs.docker.com/get-docker/).
    - Run `docker compose up` in the project root directory.
-     - To avoid running the make scripts when rebuilding, set `SKIP_MAKE_FILES=true` in your .env file. This reduces build time if all target files and docs have already been created.
+     - To avoid running the make scripts when rebuilding, add `SKIP_MAKE_FILES=true` to the file `docker/.env`. This reduces build time if all target files and docs have already been created.
+   - Visit [`http://localhost:5173/beta`](http://localhost:5173/beta).
 
 † Docker is recommended on Windows since you'll need `make` and a ideally Linux shell. You can alternatively [use in Cygwin](https://www.cygwin.com/), [install make](https://stackoverflow.com/a/73862277), or piece together what you need to run from the `Makefile` :)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,5 @@ services:
       - "5173:5173"
       - "8000:8000"
     restart: unless-stopped
-    env_file:
-      - docker/.env
     environment:
       - SKIP_MAKE_FILES=${SKIP_MAKE_FILES}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - "8000:8000"
     restart: unless-stopped
     env_file:
-      - .env
+      - docker/.env
     environment:
       - SKIP_MAKE_FILES=${SKIP_MAKE_FILES}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1
 FROM node:21.5
 
-ENV SKIP_MAKE_FILES=${SKIP_MAKE_FILES}
-
 COPY . /Cosmos-Keyboards/
 WORKDIR /Cosmos-Keyboards
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN ln -s /usr/bin/python3.11 /usr/bin/python
 RUN mkdir -p target && mkdir -p docs/assets/target
 RUN npm install --include=optional
 
-RUN if [ -f ./.env ]; then set -a && . ./.env && set +a; fi && \
+RUN if [ -f docker/.env ]; then set -a && . docker/.env && set +a; fi && \
     if [ "$SKIP_MAKE_FILES" != "true" ]; then \
         make; \
         make parts; \


### PR DESCRIPTION
It looks like since the `RUN` command is already sourcing the `.env` file, it's not necessary to include it in the `docker-compose` file. This leaves us without any way to supply runtime variables, but I don't imagine I'll be adding any runtime environment variables soon.

The end result is that `docker-compose` runs without any error if no `.env` file is present, so there's no need for any scripts to autocreate a `.env` file.

Btw I've added a GitHub action to `docker-compose build` so we catch any future regressions. This action could potentially be expanded to publish to dockerhub.