### PR TITLE
Remove .env file requirement, load directly in build and entrypoint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,3 @@ services:
       - "5173:5173"
       - "8000:8000"
     restart: unless-stopped
-    env_file:
-      - .env
-    environment:
-      - SKIP_MAKE_FILES=${SKIP_MAKE_FILES}

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,5 +5,6 @@ cp -r /Cosmos-Keyboards/* /temp-cosmos
 cp -r /temp-cosmos/* /Cosmos-Keyboards
 rm -rf /temp-cosmos
 
+if [ -f ./.env ]; then set -a && . ./.env && set +a; fi
 npx concurrently "venv/bin/mkdocs serve -a 0.0.0.0:8000" "npm:dev -- --host 0.0.0.0 --port 5173"
 exec "$@"


### PR DESCRIPTION
Removes the requirement to create an .env file when building the docker container. Loads the environment variables only if the file exists both during build and the entrypoint script. The main tradeoff with this approach is the lack of vars in the environment when shelling into the container.