### PR TITLE
Fix diode hole size

### DIFF
--- a/src/model_gen/keyholes.cljs
+++ b/src/model_gen/keyholes.cljs
@@ -303,7 +303,7 @@
 
         diode-wire-dia 0.75
         diode-wire-channel-depth (* 1.5 diode-wire-dia)
-        diode-body-width 1.95
+        diode-body-width 2.2
         diode-body-length 4
         diode-corner-hole (->> (cylinder diode-wire-dia (* 2 hotswap-z))
                               (with-fn ROUND-RES)


### PR DESCRIPTION
Fix diode hole being undersized. Increased minimum size from 1.72 to 1.85. 1N4148 can be up to 2mm in diameter and 1.85 lets 2mm diodes snap into place without shattering.