### PR TITLE
Sidenub: fix old-mx-snap-in sidenub location

### DIFF
--- a/src/model_gen/modeling.ts
+++ b/src/model_gen/modeling.ts
@@ -138,7 +138,7 @@ export function sideNub(nubHeight: number) {
 
 function makeSidenub(nubHeight: number): Solid {
   const nub = draw().ellipse(-1, 1, 1, 1).lineTo([0, 5 - nubHeight])
-    .close().translate(14 / 2, 0).sketchOnPlane('XZ', -2.75 / 2)
+    .close().translate(14 / 2, nubHeight).sketchOnPlane('XZ', -2.75 / 2)
     .extrude(2.75)
   return nub as Solid
 }


### PR DESCRIPTION
This PR should fix the sidenub location issue for the old-mx-snap-in keyhole. 
The issue was brought up here: https://github.com/rianadon/Cosmos-Keyboards/issues/44 