### PR TITLE
Lemon Wired ZMK firmware (USB split via Pico-PIO-USB)

### DIFF
--- a/docs/docs/pcbs/lemon-wired.md
+++ b/docs/docs/pcbs/lemon-wired.md
@@ -126,6 +126,29 @@ When using QMK, you will need to wire the Link-only connector on this microcontr
 
 3. Speaking of [the guide](../qmk-rp2040.md), I recommend following it if you've never used QMK before. Even if you're autogenerating your firmware, it's good to skim it so you can an idea of what the different files in QMK do.
 
+## ZMK (Phase 1)
+
+ZMK on the Lemon Wired is in early-access. The Cosmos generator can emit a ZMK config from the **Program** tab — pick **Firmware: ZMK (Phase 1, experimental)** in the Lemon Wired branch.
+
+What Phase 1 ships:
+
+- A `cosmos_lemon_wired` board in [Olson3R/rainadon-zmk](https://github.com/Olson3R/rainadon-zmk) on branch `lemon-wired-zmk-phase1`. The generator's `west.yml` pins to this remote and branch when ZMK is selected.
+- UART-based split transport over the Link USB-C port (GP0/GP1).
+- Matrix scan, encoder, VIK SPI/I2C, and ZMK Studio support.
+
+What's not in Phase 1 yet:
+
+- **No RGB underglow.** Zephyr 3.5 in the ZMK fork lacks an in-tree PIO ws2812 driver, so the generated `.conf` forces underglow off and the board overlay omits the LED strip definition. Use QMK if you need RGB today.
+- **The Link port is fixed to GP0/GP1** (the dedicated Link-only USB-C). Phase 2 will add Pico-PIO-USB so either USB-C port can be the link; Phase 3 makes both ports interchangeable.
+
+To build locally instead of via the GitHub Actions workflow:
+
+```bash
+west init -l config && west update
+west build -b cosmos_lemon_wired -- -DSHIELD=<your_folder>_left
+west build -b cosmos_lemon_wired -- -DSHIELD=<your_folder>_right
+```
+
 ## KMK Example
 
 Work in progress :) I'm working on merging my changes into CircuitPython and KMK.

--- a/src/lib/3d/Keyboard.svelte
+++ b/src/lib/3d/Keyboard.svelte
@@ -190,6 +190,7 @@
         {@const index = nthIndex($protoConfig, side, key.i)}
         <KeyboardKey
           {index}
+          {side}
           visible={visible && (!keyColor || keyColor[1] != 0)}
           position={pressedLetter && lett == pressedLetter
             ? adjustedPosition(key, translation)
@@ -219,6 +220,7 @@
       {@const index = nthIndex($protoConfig, side, key.i)}
       <KeyboardKey
         {index}
+        {side}
         visible={visible &&
           (key.key.type != 'blank' || !($noBlanks || keyColor)) &&
           (!PART_INFO[key.key.type].keycap || !switchColor || switchColor[1] != 0)}
@@ -259,6 +261,6 @@
 
       {#each keys as key}
         {@const index = nthIndex($protoConfig, side, key.i)}
-        <KeyboardKeyInstance {index} brightness={0.7} position={key.pos} rotation={key.rot} />
+        <KeyboardKeyInstance {index} {side} brightness={0.7} position={key.pos} rotation={key.rot} />
       {/each}
     </InstancedMesh> -->

--- a/src/lib/3d/KeyboardKey.svelte
+++ b/src/lib/3d/KeyboardKey.svelte
@@ -1,22 +1,31 @@
 <script lang="ts">
   import { T } from '@threlte/core'
-  import { hoveredKey, clickedKey } from '$lib/store'
+  import { hoveredKey, clickedKey, clickedVisualSide } from '$lib/store'
   import { getContext } from 'svelte'
   import type { interactivity } from '@threlte/extras'
 
   export let index: number | null
+  export let side: 'left' | 'right' | 'unibody' = 'right'
 
   type InteractivityContext = ReturnType<typeof interactivity>
   const context: InteractivityContext = getContext('interactivity')
+
+  function onClick() {
+    $clickedKey = index
+    $clickedVisualSide = side
+  }
 </script>
 
 <T.Mesh
   {...$$restProps}
   on:pointerenter={() => ($hoveredKey = index)}
   on:pointerleave={() => ($hoveredKey = null)}
-  on:click={() => ($clickedKey = index)}
+  on:click={onClick}
   on:pointermissed={() => {
-    if (!context.initialHits.length) $clickedKey = null
+    if (!context.initialHits.length) {
+      $clickedKey = null
+      $clickedVisualSide = null
+    }
   }}
 >
   <slot />

--- a/src/lib/3d/KeyboardKeyInstance.svelte
+++ b/src/lib/3d/KeyboardKeyInstance.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { hoveredKey, clickedKey, selectMode, protoConfig } from '$lib/store'
+  import { hoveredKey, clickedKey, clickedVisualSide, selectMode, protoConfig } from '$lib/store'
   import { getContext } from 'svelte'
   import { nthKey, type CosmosKeyboard } from '$lib/worker/config.cosmos'
   import { Instance, interactivity } from '@threlte/extras'
@@ -9,6 +9,12 @@
   export let index: number | null
   export let position: Vector3Tuple
   export let rotation: Vector4Tuple
+  export let side: 'left' | 'right' | 'unibody' = 'right'
+
+  function onClick() {
+    $clickedKey = index
+    $clickedVisualSide = side
+  }
 
   type InteractivityContext = ReturnType<typeof interactivity>
   const context: InteractivityContext = getContext('interactivity')
@@ -41,8 +47,11 @@
   quaternion={rotation}
   on:pointerenter={() => ($hoveredKey = index)}
   on:pointerleave={() => ($hoveredKey = null)}
-  on:click={() => ($clickedKey = index)}
+  on:click={onClick}
   on:pointermissed={() => {
-    if (!context.initialHits.length) $clickedKey = null
+    if (!context.initialHits.length) {
+      $clickedKey = null
+      $clickedVisualSide = null
+    }
   }}
 />

--- a/src/lib/geometry/keycaps.ts
+++ b/src/lib/geometry/keycaps.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LAYOUT, flipLetter, type LayoutId } from '$lib/layouts'
 import type { CuttleKey } from '$lib/worker/config'
 import type { Profile } from '$target/cosmosStructs'
 
@@ -127,19 +128,18 @@ export function keyInfo(k: CuttleKey) {
   return KEY_INFO[k.keycap.profile][k.keycap.row]
 }
 
+// Number-row and F-row mirror map (layout-independent for letter-swap layouts).
 // dprint-ignore
-const FLIPPED_KEY: Record<string, string> = {
+const SHARED_FLIP: Record<string, string> = {
   0: '1', 9: '2', 8: '3', 7: '4', 6: '5',
-  p: 'q', o: 'w', i: 'e', u: 'r', y: 't',
-  ';': 'a', l: 's', k: 'd', j: 'f', h: 'g',
-  '/': 'z', '.': 'x', ',': 'c', 'm': 'v', n: 'b',
-  'F10': 'F1', 'F9': 'F2', 'F8': 'F3', 'F7': 'F4', 'F6': 'F5'
+  'F10': 'F1', 'F9': 'F2', 'F8': 'F3', 'F7': 'F4', 'F6': 'F5',
 }
-for (const k of Object.keys(FLIPPED_KEY)) FLIPPED_KEY[FLIPPED_KEY[k]] = k
+for (const k of Object.keys(SHARED_FLIP)) SHARED_FLIP[SHARED_FLIP[k]] = k
 
-export function flippedKey(letter: string | undefined) {
+export function flippedKey(letter: string | undefined, layout: LayoutId = DEFAULT_LAYOUT) {
   if (!letter) return letter
-  return FLIPPED_KEY[letter] ?? letter
+  if (letter in SHARED_FLIP) return SHARED_FLIP[letter]
+  return flipLetter(letter, layout) ?? letter
 }
 
 const KEY_MATRIX = [

--- a/src/lib/layouts/index.ts
+++ b/src/lib/layouts/index.ts
@@ -200,6 +200,33 @@ export function isLayoutId(value: unknown): value is LayoutId {
   return typeof value === 'string' && value in REGISTRY
 }
 
+const ALPHA_LETTERS: ReadonlySet<string> = new Set(
+  LAYOUT_IDS.flatMap(id => {
+    const layout = REGISTRY[id]
+    return [
+      ...layout.rightRows[2],
+      ...layout.rightRows[3],
+      ...layout.rightRows[4],
+      ...Object.keys(layout.flipMap),
+      ...Object.values(layout.flipMap),
+    ]
+  }),
+)
+
+/**
+ * True iff `letter` is a legend that any registered layout places in its
+ * alpha rows (right side or, after flipping, left side).
+ *
+ * Used to gate layout-swap operations so they don't touch outer punctuation
+ * (`{`, `}`, `[`, `]`, `\` from row 5 — which `keycapInfo()` collapses to
+ * `profile.row = 4` for MT3 keycap-profile reasons, defeating a row-based
+ * filter).
+ */
+export function isAlphaLetter(letter: string | undefined): boolean {
+  if (!letter) return false
+  return ALPHA_LETTERS.has(letter)
+}
+
 /** Returns the right-side legend for (row, col) in the given layout, or undefined. */
 export function rightSideLetter(row: number, col: number, layoutId: LayoutId = DEFAULT_LAYOUT): string | undefined {
   const layout = getLayout(layoutId)

--- a/src/lib/layouts/index.ts
+++ b/src/lib/layouts/index.ts
@@ -43,6 +43,8 @@ export const DEFAULT_LAYOUT: NamedLayoutId = LAYOUT.QWERTY
 export interface KeyboardLayout {
   id: LayoutId
   name: string
+  /** One- or two-sentence summary shown in the layout-picker tooltip. */
+  description: string
   /** Right-side rows. Each string holds letters for columns 0..N. */
   rightRows: { 2: string; 3: string; 4: string }
   /** Right-side letter -> left-side letter mirror map. */
@@ -52,6 +54,7 @@ export interface KeyboardLayout {
 const QWERTY: KeyboardLayout = {
   id: LAYOUT.QWERTY,
   name: 'QWERTY',
+  description: 'The standard layout shipped on virtually every keyboard. Familiar but not optimized — common letters are spread across rows.',
   rightRows: {
     2: 'yuiop',
     3: "hjkl;'",
@@ -79,6 +82,7 @@ const QWERTY: KeyboardLayout = {
 const COLEMAK: KeyboardLayout = {
   id: LAYOUT.COLEMAK,
   name: 'Colemak',
+  description: 'Common letters concentrated on the home row, only 17 keys move from QWERTY. Easier to learn from QWERTY than Dvorak.',
   rightRows: {
     2: 'jluy;',
     3: "hneio'",
@@ -106,6 +110,7 @@ const COLEMAK: KeyboardLayout = {
 const COLEMAK_DH: KeyboardLayout = {
   id: LAYOUT.COLEMAK_DH,
   name: 'Colemak-DH',
+  description: 'A modern Colemak variant that swaps D/H to keep index-finger reach off the bottom-center keys. Popular on column-staggered ergo boards.',
   rightRows: {
     2: 'jluy;',
     3: "mneio'",
@@ -133,6 +138,7 @@ const COLEMAK_DH: KeyboardLayout = {
 const DVORAK: KeyboardLayout = {
   id: LAYOUT.DVORAK,
   name: 'Dvorak',
+  description: 'Vowels under the left hand, common consonants under the right. Big departure from QWERTY (rebuilds muscle memory) but loved by long-time users.',
   rightRows: {
     2: 'fgcrl/',
     3: 'dhtns-',
@@ -160,6 +166,7 @@ const DVORAK: KeyboardLayout = {
 const WORKMAN: KeyboardLayout = {
   id: LAYOUT.WORKMAN,
   name: 'Workman',
+  description: 'Tries to balance hand and finger usage by avoiding QWERTY/Colemak hot spots. Less mainstream but a good fit for staggered keyboards.',
   rightRows: {
     2: 'jfup;',
     3: "yneoi'",

--- a/src/lib/layouts/index.ts
+++ b/src/lib/layouts/index.ts
@@ -1,0 +1,221 @@
+/**
+ * Keyboard layout definitions for the Cosmos editor.
+ *
+ * A layout maps physical key positions (row, column) to printed legends. The
+ * `row` value matches the row index used by `letterForKeycap()` in
+ * `worker/config.ts`:
+ *   row 0 = function row (F-keys)            — layout-independent
+ *   row 1 = number row                       — layout-independent
+ *   row 2 = top alpha row
+ *   row 3 = home row
+ *   row 4 = bottom alpha row
+ *   row 5 = outer punctuation/wide pinky     — layout-independent
+ *
+ * Each layout supplies the right-side letters for rows 2/3/4. Number, F, and
+ * pinky-punctuation rows are shared across all letter-swap layouts and live in
+ * `letterForKeycap()`.
+ *
+ * `flipMap` mirrors a right-side letter to its left-side counterpart for split
+ * keyboards. The map only needs to cover one direction; consumers handle the
+ * inverse.
+ */
+
+export const LAYOUT = {
+  QWERTY: 'qwerty',
+  COLEMAK: 'colemak',
+  COLEMAK_DH: 'colemak-dh',
+  DVORAK: 'dvorak',
+  WORKMAN: 'workman',
+} as const
+
+export type LayoutId = (typeof LAYOUT)[keyof typeof LAYOUT]
+
+export const DEFAULT_LAYOUT: LayoutId = LAYOUT.QWERTY
+
+export interface KeyboardLayout {
+  id: LayoutId
+  name: string
+  /** Right-side rows. Each string holds letters for columns 0..N. */
+  rightRows: { 2: string; 3: string; 4: string }
+  /** Right-side letter -> left-side letter mirror map. */
+  flipMap: Record<string, string>
+}
+
+const QWERTY: KeyboardLayout = {
+  id: LAYOUT.QWERTY,
+  name: 'QWERTY',
+  rightRows: {
+    2: 'yuiop',
+    3: "hjkl;'",
+    4: 'nm,./',
+  },
+  flipMap: {
+    y: 't',
+    u: 'r',
+    i: 'e',
+    o: 'w',
+    p: 'q',
+    h: 'g',
+    j: 'f',
+    k: 'd',
+    l: 's',
+    ';': 'a',
+    n: 'b',
+    m: 'v',
+    ',': 'c',
+    '.': 'x',
+    '/': 'z',
+  },
+}
+
+const COLEMAK: KeyboardLayout = {
+  id: LAYOUT.COLEMAK,
+  name: 'Colemak',
+  rightRows: {
+    2: 'jluy;',
+    3: "hneio'",
+    4: 'km,./',
+  },
+  flipMap: {
+    j: 'g',
+    l: 'p',
+    u: 'f',
+    y: 'w',
+    ';': 'q',
+    h: 'd',
+    n: 't',
+    e: 's',
+    i: 'r',
+    o: 'a',
+    k: 'b',
+    m: 'v',
+    ',': 'c',
+    '.': 'x',
+    '/': 'z',
+  },
+}
+
+const COLEMAK_DH: KeyboardLayout = {
+  id: LAYOUT.COLEMAK_DH,
+  name: 'Colemak-DH',
+  rightRows: {
+    2: 'jluy;',
+    3: "mneio'",
+    4: 'kh,./',
+  },
+  flipMap: {
+    j: 'b',
+    l: 'p',
+    u: 'f',
+    y: 'w',
+    ';': 'q',
+    m: 'g',
+    n: 't',
+    e: 's',
+    i: 'r',
+    o: 'a',
+    k: 'z',
+    h: 'x',
+    ',': 'c',
+    '.': 'd',
+    '/': 'v',
+  },
+}
+
+const DVORAK: KeyboardLayout = {
+  id: LAYOUT.DVORAK,
+  name: 'Dvorak',
+  rightRows: {
+    2: 'fgcrl/',
+    3: 'dhtns-',
+    4: 'bmwvz',
+  },
+  flipMap: {
+    f: 'y',
+    g: 'p',
+    c: '.',
+    r: ',',
+    l: "'",
+    d: 'i',
+    h: 'u',
+    t: 'e',
+    n: 'o',
+    s: 'a',
+    b: 'x',
+    m: 'q',
+    w: 'j',
+    v: 'k',
+    z: ';',
+  },
+}
+
+const WORKMAN: KeyboardLayout = {
+  id: LAYOUT.WORKMAN,
+  name: 'Workman',
+  rightRows: {
+    2: 'jfup;',
+    3: "yneoi'",
+    4: 'kl,./',
+  },
+  flipMap: {
+    j: 'b',
+    f: 'w',
+    u: 'r',
+    p: 'd',
+    ';': 'q',
+    y: 'g',
+    n: 't',
+    e: 'h',
+    o: 's',
+    i: 'a',
+    k: 'v',
+    l: 'c',
+    ',': 'm',
+    '.': 'x',
+    '/': 'z',
+  },
+}
+
+const REGISTRY: Record<LayoutId, KeyboardLayout> = {
+  [LAYOUT.QWERTY]: QWERTY,
+  [LAYOUT.COLEMAK]: COLEMAK,
+  [LAYOUT.COLEMAK_DH]: COLEMAK_DH,
+  [LAYOUT.DVORAK]: DVORAK,
+  [LAYOUT.WORKMAN]: WORKMAN,
+}
+
+export const LAYOUT_IDS: readonly LayoutId[] = [
+  LAYOUT.QWERTY,
+  LAYOUT.COLEMAK,
+  LAYOUT.COLEMAK_DH,
+  LAYOUT.DVORAK,
+  LAYOUT.WORKMAN,
+]
+
+export function getLayout(id: LayoutId | undefined | null): KeyboardLayout {
+  return REGISTRY[id ?? DEFAULT_LAYOUT] ?? QWERTY
+}
+
+export function isLayoutId(value: unknown): value is LayoutId {
+  return typeof value === 'string' && value in REGISTRY
+}
+
+/** Returns the right-side legend for (row, col) in the given layout, or undefined. */
+export function rightSideLetter(row: number, col: number, layoutId: LayoutId = DEFAULT_LAYOUT): string | undefined {
+  const layout = getLayout(layoutId)
+  if (row === 2 || row === 3 || row === 4) {
+    return layout.rightRows[row].charAt(col) || undefined
+  }
+  return undefined
+}
+
+/** Returns the left-side mirror of `letter` in the given layout. */
+export function flipLetter(letter: string | undefined, layoutId: LayoutId = DEFAULT_LAYOUT): string | undefined {
+  if (!letter) return letter
+  const layout = getLayout(layoutId)
+  if (letter in layout.flipMap) return layout.flipMap[letter]
+  for (const [right, left] of Object.entries(layout.flipMap)) {
+    if (left === letter) return right
+  }
+  return letter
+}

--- a/src/lib/layouts/index.ts
+++ b/src/lib/layouts/index.ts
@@ -26,11 +26,19 @@ export const LAYOUT = {
   COLEMAK_DH: 'colemak-dh',
   DVORAK: 'dvorak',
   WORKMAN: 'workman',
+  /** User-edited layout that doesn't match any registered named layout.
+   *  Has no rightRows/flipMap — `getLayout(CUSTOM)` returns undefined and
+   *  callers must guard. Set automatically when the user edits an alpha
+   *  legend or removes an alpha column; can also be picked manually. */
+  CUSTOM: 'custom',
 } as const
 
 export type LayoutId = (typeof LAYOUT)[keyof typeof LAYOUT]
 
-export const DEFAULT_LAYOUT: LayoutId = LAYOUT.QWERTY
+/** Layouts with concrete letter mappings (everything except CUSTOM). */
+export type NamedLayoutId = Exclude<LayoutId, 'custom'>
+
+export const DEFAULT_LAYOUT: NamedLayoutId = LAYOUT.QWERTY
 
 export interface KeyboardLayout {
   id: LayoutId
@@ -176,7 +184,7 @@ const WORKMAN: KeyboardLayout = {
   },
 }
 
-const REGISTRY: Record<LayoutId, KeyboardLayout> = {
+const REGISTRY: Record<NamedLayoutId, KeyboardLayout> = {
   [LAYOUT.QWERTY]: QWERTY,
   [LAYOUT.COLEMAK]: COLEMAK,
   [LAYOUT.COLEMAK_DH]: COLEMAK_DH,
@@ -184,7 +192,8 @@ const REGISTRY: Record<LayoutId, KeyboardLayout> = {
   [LAYOUT.WORKMAN]: WORKMAN,
 }
 
-export const LAYOUT_IDS: readonly LayoutId[] = [
+/** Concrete-mapping layouts (everything in the dropdown except CUSTOM). */
+export const NAMED_LAYOUT_IDS: readonly NamedLayoutId[] = [
   LAYOUT.QWERTY,
   LAYOUT.COLEMAK,
   LAYOUT.COLEMAK_DH,
@@ -192,16 +201,34 @@ export const LAYOUT_IDS: readonly LayoutId[] = [
   LAYOUT.WORKMAN,
 ]
 
+/** All layouts shown in the picker, including CUSTOM. */
+export const LAYOUT_IDS: readonly LayoutId[] = [...NAMED_LAYOUT_IDS, LAYOUT.CUSTOM]
+
+export const LAYOUT_NAMES: Record<LayoutId, string> = {
+  [LAYOUT.QWERTY]: QWERTY.name,
+  [LAYOUT.COLEMAK]: COLEMAK.name,
+  [LAYOUT.COLEMAK_DH]: COLEMAK_DH.name,
+  [LAYOUT.DVORAK]: DVORAK.name,
+  [LAYOUT.WORKMAN]: WORKMAN.name,
+  [LAYOUT.CUSTOM]: 'Custom',
+}
+
+export function isNamedLayoutId(id: LayoutId | undefined | null): id is NamedLayoutId {
+  return typeof id === 'string' && id !== LAYOUT.CUSTOM && id in REGISTRY
+}
+
 export function getLayout(id: LayoutId | undefined | null): KeyboardLayout {
-  return REGISTRY[id ?? DEFAULT_LAYOUT] ?? QWERTY
+  if (id && id !== LAYOUT.CUSTOM && id in REGISTRY) return REGISTRY[id as NamedLayoutId]
+  return QWERTY
 }
 
 export function isLayoutId(value: unknown): value is LayoutId {
-  return typeof value === 'string' && value in REGISTRY
+  if (typeof value !== 'string') return false
+  return value === LAYOUT.CUSTOM || value in REGISTRY
 }
 
 const ALPHA_LETTERS: ReadonlySet<string> = new Set(
-  LAYOUT_IDS.flatMap(id => {
+  NAMED_LAYOUT_IDS.flatMap(id => {
     const layout = REGISTRY[id]
     return [
       ...layout.rightRows[2],

--- a/src/lib/layouts/layoutEndToEnd.test.ts
+++ b/src/lib/layouts/layoutEndToEnd.test.ts
@@ -1,0 +1,159 @@
+/**
+ * End-to-end tests for the layout feature: round-trips through serialization,
+ * applyLayoutToKeys against a CosmosKeyboard, and ZMK/QMK keycode generation.
+ */
+
+import defaultConfig from '$assets/cuttleform.json' assert { type: 'json' }
+import { expect, test } from 'bun:test'
+import { applyLayoutToKeys } from '../../routes/beta/lib/editor/visualEditorHelpers'
+import { keycode as qmkKeycode } from '../../routes/beta/lib/firmware/qmk'
+import { keycode as zmkKeycode } from '../../routes/beta/lib/firmware/zmk'
+import { cuttleConf } from '../worker/config'
+import { type CosmosKeyboard, toCosmosConfig } from '../worker/config.cosmos'
+import { decodeConfigIdk, encodeCosmosConfig, serializeCosmosConfig } from '../worker/config.serialize'
+import { LAYOUT, LAYOUT_IDS, type LayoutId } from './index'
+
+function buildDefaultCosmos(): CosmosKeyboard {
+  const config = cuttleConf(defaultConfig.options as any)
+  const cosmos = toCosmosConfig(config, 'right', true)
+  cosmos.wristRestPosition = 0n
+  return cosmos
+}
+
+test('layout round-trips through serialize/deserialize for every layout', () => {
+  for (const layoutId of LAYOUT_IDS) {
+    const cosmos = buildDefaultCosmos()
+    cosmos.layout = layoutId
+    const encoded = serializeCosmosConfig(encodeCosmosConfig(cosmos))
+    const decoded = decodeConfigIdk(encoded)
+    expect(decoded.layout).toBe(layoutId)
+  }
+})
+
+test('omitted layout decodes as QWERTY (back-compat)', () => {
+  // An older URL encoded before this feature has no layout field. Decoding it
+  // should produce a QWERTY config so existing shared keyboards still work.
+  const legacyEncoded =
+    'Cn8KDxIFEIA/ICcSABIAEgA4MQoPEgUQgEsgJxIAEgASADgdChwSBRCAVyAnEgASABIDELAvEgMQsF84CUCE8LwCChcSBRCAYyAnEgASABIDELA7EgMQsGs4CgoVEgUQgG8gJxIAEgASADgeQJCGirAHGABA6IWgrvBVSNzwoqABCpIBChcSExDAwAJAgICYAkjCmaCVkLwBUEM4CAoVEhAQQECAgCBI0JWA3ZD1A1ALUJ4CChYSEhBAQICAzAJIwpmglZC8AVCGAVA6ChQSEBBAQICA+AFI5pn8p5ALUFdQfwoVEhAQQECAgKQDSPCZzLXQMFB0UJUBGAIiCgjIARDIARgAIABAy4uEpNAxSK2R3I3BkwZyAA=='
+  const decoded = decodeConfigIdk(legacyEncoded)
+  expect(decoded.layout).toBe(LAYOUT.QWERTY)
+})
+
+test('applyLayoutToKeys updates alpha-row letters per layout', () => {
+  // The default Cosmos config has finger clusters with QWERTY letters baked
+  // into key.profile.letter from cosmosFingers(). Applying Colemak should
+  // rewrite the alpha-block letters and leave non-alpha rows alone.
+  const baseline = buildDefaultCosmos()
+
+  function letterAt(kbd: CosmosKeyboard, side: 'left' | 'right', row: number, alphaIdx: number) {
+    const cluster = kbd.clusters.find(c => c.name === 'fingers' && c.side === side)
+    if (!cluster) return undefined
+    // Find the alphaIdx-th column in physical-position order that has letters,
+    // then the key in that column with profile.row === row.
+    const cols = cluster.clusters
+      .map((col, idx) => ({ idx, column: col.column ?? -1000, hasLetters: col.keys.some(k => !!k.profile.letter) }))
+      .filter(c => c.hasLetters)
+      .sort((a, b) => a.column - b.column)
+    const col = cluster.clusters[cols[alphaIdx]?.idx]
+    if (!col) return undefined
+    return col.keys.find(k => k.profile.row === row)?.profile.letter
+  }
+
+  // Sanity: baseline is QWERTY.
+  expect(letterAt(baseline, 'right', 3, 0)).toBe('h') // home row, leftmost alpha (closest to center)
+  expect(letterAt(baseline, 'right', 3, 1)).toBe('j')
+
+  const colemakDH = applyLayoutToKeys(buildDefaultCosmos(), LAYOUT.COLEMAK_DH)
+  expect(letterAt(colemakDH, 'right', 3, 0)).toBe('m')
+  expect(letterAt(colemakDH, 'right', 3, 1)).toBe('n')
+
+  const dvorak = applyLayoutToKeys(buildDefaultCosmos(), LAYOUT.DVORAK)
+  expect(letterAt(dvorak, 'right', 3, 0)).toBe('d')
+  expect(letterAt(dvorak, 'right', 3, 2)).toBe('t')
+})
+
+test('applyLayoutToKeys leaves number row untouched', () => {
+  // Numbers and F-keys are layout-independent — applying any layout should
+  // not change them. The default config has number keys with letters '6'..'0'.
+  const before = buildDefaultCosmos()
+  const numberKeysBefore = collectLetters(before, 1) // row 1 = number row
+  expect(numberKeysBefore.length).toBeGreaterThan(0)
+
+  const after = applyLayoutToKeys(before, LAYOUT.COLEMAK)
+  const numberKeysAfter = collectLetters(after, 1)
+  expect(numberKeysAfter).toEqual(numberKeysBefore)
+})
+
+function collectLetters(kbd: CosmosKeyboard, profileRow: number): string[] {
+  const out: string[] = []
+  for (const cluster of kbd.clusters) {
+    if (cluster.name !== 'fingers') continue
+    for (const col of cluster.clusters) {
+      for (const key of col.keys) {
+        if (key.profile.row === profileRow && key.profile.letter) out.push(key.profile.letter)
+      }
+    }
+  }
+  return out
+}
+
+const ZMK_LETTER_TO_KEYCODE: Record<string, string> = {
+  a: '&kp A',
+  h: '&kp H',
+  n: '&kp N',
+  m: '&kp M',
+  t: '&kp T',
+  e: '&kp E',
+  i: '&kp I',
+  d: '&kp D',
+  s: '&kp S',
+  r: '&kp R',
+}
+const QMK_LETTER_TO_KEYCODE: Record<string, string> = {
+  a: 'KC_A',
+  h: 'KC_H',
+  n: 'KC_N',
+  m: 'KC_M',
+  t: 'KC_T',
+  e: 'KC_E',
+  i: 'KC_I',
+  d: 'KC_D',
+  s: 'KC_S',
+  r: 'KC_R',
+}
+
+test('ZMK keycode emits letter-specific code for each alpha letter', () => {
+  for (const [letter, code] of Object.entries(ZMK_LETTER_TO_KEYCODE)) {
+    expect(zmkKeycode(letter)).toBe(code)
+  }
+})
+
+test('QMK keycode emits letter-specific code for each alpha letter', () => {
+  for (const [letter, code] of Object.entries(QMK_LETTER_TO_KEYCODE)) {
+    expect(qmkKeycode(letter)).toBe(code)
+  }
+})
+
+test('ZMK home-row keycodes change between QWERTY and Colemak DH', () => {
+  // The same physical position (home row, index-finger column) emits different
+  // keycodes depending on the layout. This is the end-to-end contract: change
+  // the layout, the firmware sends a different key.
+  const expectations: Array<{ layout: LayoutId; rightHomeFirstAlpha: string }> = [
+    { layout: LAYOUT.QWERTY, rightHomeFirstAlpha: 'h' },
+    { layout: LAYOUT.COLEMAK, rightHomeFirstAlpha: 'h' }, // Colemak keeps H here
+    { layout: LAYOUT.COLEMAK_DH, rightHomeFirstAlpha: 'm' },
+    { layout: LAYOUT.DVORAK, rightHomeFirstAlpha: 'd' },
+    { layout: LAYOUT.WORKMAN, rightHomeFirstAlpha: 'y' },
+  ]
+  for (const { layout, rightHomeFirstAlpha } of expectations) {
+    const kbd = applyLayoutToKeys(buildDefaultCosmos(), layout)
+    const cluster = kbd.clusters.find(c => c.name === 'fingers' && c.side === 'right')!
+    const homeKeys = cluster.clusters.flatMap(c => c.keys.filter(k => k.profile.row === 3 && k.profile.letter))
+    const sortedByCol = homeKeys
+      .map(k => ({ letter: k.profile.letter!, col: cluster.clusters.find(c => c.keys.includes(k))?.column ?? 0 }))
+      .sort((a, b) => a.col - b.col)
+    expect(sortedByCol[0].letter).toBe(rightHomeFirstAlpha)
+    expect(zmkKeycode(sortedByCol[0].letter)).toBe(`&kp ${rightHomeFirstAlpha.toUpperCase()}`)
+    expect(qmkKeycode(sortedByCol[0].letter)).toBe(`KC_${rightHomeFirstAlpha.toUpperCase()}`)
+  }
+})

--- a/src/lib/layouts/layoutEndToEnd.test.ts
+++ b/src/lib/layouts/layoutEndToEnd.test.ts
@@ -9,7 +9,7 @@ import { applyLayoutToKeys } from '../../routes/beta/lib/editor/visualEditorHelp
 import { keycode as qmkKeycode } from '../../routes/beta/lib/firmware/qmk'
 import { keycode as zmkKeycode } from '../../routes/beta/lib/firmware/zmk'
 import { cuttleConf } from '../worker/config'
-import { type CosmosKeyboard, toCosmosConfig } from '../worker/config.cosmos'
+import { type CosmosKeyboard, detectLayout, toCosmosConfig } from '../worker/config.cosmos'
 import { decodeConfigIdk, encodeCosmosConfig, serializeCosmosConfig } from '../worker/config.serialize'
 import { LAYOUT, LAYOUT_IDS, type LayoutId } from './index'
 
@@ -20,23 +20,26 @@ function buildDefaultCosmos(): CosmosKeyboard {
   return cosmos
 }
 
-test('layout round-trips through serialize/deserialize for every layout', () => {
+test('layout survives serialize/deserialize via the keys, not a stored field', () => {
+  // Layout is a function of the alpha-key labels — serialize/deserialize
+  // round-trips the letters in cluster.col.keys[].profile.letter, and
+  // detectLayout(decoded) re-derives the named layout from those letters.
   for (const layoutId of LAYOUT_IDS) {
-    const cosmos = buildDefaultCosmos()
-    cosmos.layout = layoutId
+    if (layoutId === LAYOUT.CUSTOM) continue // CUSTOM has no canonical letters
+    const cosmos = applyLayoutToKeys(buildDefaultCosmos(), layoutId)
     const encoded = serializeCosmosConfig(encodeCosmosConfig(cosmos))
     const decoded = decodeConfigIdk(encoded)
-    expect(decoded.layout).toBe(layoutId)
+    expect(detectLayout(decoded as unknown as CosmosKeyboard)).toBe(layoutId)
   }
 })
 
-test('omitted layout decodes as QWERTY (back-compat)', () => {
-  // An older URL encoded before this feature has no layout field. Decoding it
-  // should produce a QWERTY config so existing shared keyboards still work.
+test('legacy URL with default letters detects as QWERTY (back-compat)', () => {
+  // Old URLs (before the layouts feature) had QWERTY letters baked into
+  // their keys; decoding them and detecting should still return QWERTY.
   const legacyEncoded =
     'Cn8KDxIFEIA/ICcSABIAEgA4MQoPEgUQgEsgJxIAEgASADgdChwSBRCAVyAnEgASABIDELAvEgMQsF84CUCE8LwCChcSBRCAYyAnEgASABIDELA7EgMQsGs4CgoVEgUQgG8gJxIAEgASADgeQJCGirAHGABA6IWgrvBVSNzwoqABCpIBChcSExDAwAJAgICYAkjCmaCVkLwBUEM4CAoVEhAQQECAgCBI0JWA3ZD1A1ALUJ4CChYSEhBAQICAzAJIwpmglZC8AVCGAVA6ChQSEBBAQICA+AFI5pn8p5ALUFdQfwoVEhAQQECAgKQDSPCZzLXQMFB0UJUBGAIiCgjIARDIARgAIABAy4uEpNAxSK2R3I3BkwZyAA=='
   const decoded = decodeConfigIdk(legacyEncoded)
-  expect(decoded.layout).toBe(LAYOUT.QWERTY)
+  expect(detectLayout(decoded as unknown as CosmosKeyboard)).toBe(LAYOUT.QWERTY)
 })
 
 test('applyLayoutToKeys updates alpha-row letters per layout', () => {

--- a/src/lib/layouts/layouts.test.ts
+++ b/src/lib/layouts/layouts.test.ts
@@ -1,0 +1,82 @@
+import { expect, test } from 'bun:test'
+import { DEFAULT_LAYOUT, flipLetter, getLayout, isLayoutId, LAYOUT, LAYOUT_IDS, rightSideLetter } from './index'
+
+test('DEFAULT_LAYOUT is QWERTY', () => {
+  expect(DEFAULT_LAYOUT).toBe(LAYOUT.QWERTY)
+})
+
+test('LAYOUT_IDS contains all five layouts', () => {
+  expect(LAYOUT_IDS).toEqual([
+    LAYOUT.QWERTY,
+    LAYOUT.COLEMAK,
+    LAYOUT.COLEMAK_DH,
+    LAYOUT.DVORAK,
+    LAYOUT.WORKMAN,
+  ])
+})
+
+test('isLayoutId rejects unknown values', () => {
+  expect(isLayoutId('qwerty')).toBe(true)
+  expect(isLayoutId('colemak')).toBe(true)
+  expect(isLayoutId('hjkl')).toBe(false)
+  expect(isLayoutId(undefined)).toBe(false)
+  expect(isLayoutId(null)).toBe(false)
+})
+
+test('getLayout falls back to QWERTY for invalid input', () => {
+  expect(getLayout(undefined).id).toBe(LAYOUT.QWERTY)
+  expect(getLayout(null).id).toBe(LAYOUT.QWERTY)
+})
+
+test('rightSideLetter returns correct QWERTY letters', () => {
+  expect(rightSideLetter(2, 0, LAYOUT.QWERTY)).toBe('y')
+  expect(rightSideLetter(3, 0, LAYOUT.QWERTY)).toBe('h')
+  expect(rightSideLetter(3, 5, LAYOUT.QWERTY)).toBe("'")
+  expect(rightSideLetter(4, 4, LAYOUT.QWERTY)).toBe('/')
+})
+
+test('rightSideLetter returns correct Colemak letters', () => {
+  expect(rightSideLetter(2, 0, LAYOUT.COLEMAK)).toBe('j')
+  expect(rightSideLetter(3, 1, LAYOUT.COLEMAK)).toBe('n')
+  expect(rightSideLetter(3, 4, LAYOUT.COLEMAK)).toBe('o')
+})
+
+test('rightSideLetter returns correct Colemak-DH letters', () => {
+  expect(rightSideLetter(3, 0, LAYOUT.COLEMAK_DH)).toBe('m')
+  expect(rightSideLetter(4, 0, LAYOUT.COLEMAK_DH)).toBe('k')
+  expect(rightSideLetter(4, 1, LAYOUT.COLEMAK_DH)).toBe('h')
+})
+
+test('rightSideLetter returns correct Dvorak letters', () => {
+  expect(rightSideLetter(2, 0, LAYOUT.DVORAK)).toBe('f')
+  expect(rightSideLetter(3, 2, LAYOUT.DVORAK)).toBe('t')
+  expect(rightSideLetter(4, 0, LAYOUT.DVORAK)).toBe('b')
+})
+
+test('rightSideLetter returns correct Workman letters', () => {
+  expect(rightSideLetter(2, 1, LAYOUT.WORKMAN)).toBe('f')
+  expect(rightSideLetter(3, 1, LAYOUT.WORKMAN)).toBe('n')
+  expect(rightSideLetter(4, 0, LAYOUT.WORKMAN)).toBe('k')
+})
+
+test('rightSideLetter returns undefined for non-alpha rows', () => {
+  expect(rightSideLetter(0, 0, LAYOUT.COLEMAK)).toBeUndefined()
+  expect(rightSideLetter(1, 0, LAYOUT.COLEMAK)).toBeUndefined()
+  expect(rightSideLetter(5, 0, LAYOUT.COLEMAK)).toBeUndefined()
+})
+
+test('flipLetter is bidirectional within a layout', () => {
+  expect(flipLetter('y', LAYOUT.QWERTY)).toBe('t')
+  expect(flipLetter('t', LAYOUT.QWERTY)).toBe('y')
+  expect(flipLetter('h', LAYOUT.COLEMAK)).toBe('d')
+  expect(flipLetter('d', LAYOUT.COLEMAK)).toBe('h')
+})
+
+test('flipLetter passes through letters not in the flip map', () => {
+  expect(flipLetter('1', LAYOUT.QWERTY)).toBe('1')
+  expect(flipLetter('F1', LAYOUT.QWERTY)).toBe('F1')
+})
+
+test('flipLetter handles undefined gracefully', () => {
+  expect(flipLetter(undefined, LAYOUT.QWERTY)).toBeUndefined()
+})

--- a/src/lib/layouts/layouts.test.ts
+++ b/src/lib/layouts/layouts.test.ts
@@ -1,18 +1,54 @@
 import { expect, test } from 'bun:test'
-import { DEFAULT_LAYOUT, flipLetter, getLayout, isAlphaLetter, isLayoutId, LAYOUT, LAYOUT_IDS, rightSideLetter } from './index'
+import { DEFAULT_LAYOUT, flipLetter, getLayout, isAlphaLetter, isLayoutId, isNamedLayoutId, LAYOUT, LAYOUT_IDS, LAYOUT_NAMES, NAMED_LAYOUT_IDS, rightSideLetter } from './index'
 
 test('DEFAULT_LAYOUT is QWERTY', () => {
   expect(DEFAULT_LAYOUT).toBe(LAYOUT.QWERTY)
 })
 
-test('LAYOUT_IDS contains all five layouts', () => {
-  expect(LAYOUT_IDS).toEqual([
+test('NAMED_LAYOUT_IDS contains all five concrete layouts (no CUSTOM)', () => {
+  expect(NAMED_LAYOUT_IDS).toEqual([
     LAYOUT.QWERTY,
     LAYOUT.COLEMAK,
     LAYOUT.COLEMAK_DH,
     LAYOUT.DVORAK,
     LAYOUT.WORKMAN,
   ])
+  expect(NAMED_LAYOUT_IDS).not.toContain(LAYOUT.CUSTOM)
+})
+
+test('LAYOUT_IDS includes CUSTOM as the last option', () => {
+  expect(LAYOUT_IDS).toEqual([
+    LAYOUT.QWERTY,
+    LAYOUT.COLEMAK,
+    LAYOUT.COLEMAK_DH,
+    LAYOUT.DVORAK,
+    LAYOUT.WORKMAN,
+    LAYOUT.CUSTOM,
+  ])
+})
+
+test('LAYOUT_NAMES has a label for every layout id', () => {
+  for (const id of LAYOUT_IDS) {
+    expect(LAYOUT_NAMES[id]).toBeTruthy()
+  }
+  expect(LAYOUT_NAMES[LAYOUT.CUSTOM]).toBe('Custom')
+})
+
+test('isNamedLayoutId distinguishes CUSTOM from real layouts', () => {
+  expect(isNamedLayoutId(LAYOUT.QWERTY)).toBe(true)
+  expect(isNamedLayoutId(LAYOUT.COLEMAK_DH)).toBe(true)
+  expect(isNamedLayoutId(LAYOUT.CUSTOM)).toBe(false)
+  expect(isNamedLayoutId(undefined)).toBe(false)
+  expect(isNamedLayoutId(null)).toBe(false)
+})
+
+test('isLayoutId accepts CUSTOM', () => {
+  expect(isLayoutId(LAYOUT.CUSTOM)).toBe(true)
+  expect(isLayoutId('custom')).toBe(true)
+})
+
+test('getLayout(CUSTOM) falls back to QWERTY', () => {
+  expect(getLayout(LAYOUT.CUSTOM).id).toBe(LAYOUT.QWERTY)
 })
 
 test('isLayoutId rejects unknown values', () => {

--- a/src/lib/layouts/layouts.test.ts
+++ b/src/lib/layouts/layouts.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'bun:test'
-import { DEFAULT_LAYOUT, flipLetter, getLayout, isLayoutId, LAYOUT, LAYOUT_IDS, rightSideLetter } from './index'
+import { DEFAULT_LAYOUT, flipLetter, getLayout, isAlphaLetter, isLayoutId, LAYOUT, LAYOUT_IDS, rightSideLetter } from './index'
 
 test('DEFAULT_LAYOUT is QWERTY', () => {
   expect(DEFAULT_LAYOUT).toBe(LAYOUT.QWERTY)
@@ -79,4 +79,41 @@ test('flipLetter passes through letters not in the flip map', () => {
 
 test('flipLetter handles undefined gracefully', () => {
   expect(flipLetter(undefined, LAYOUT.QWERTY)).toBeUndefined()
+})
+
+test('isAlphaLetter recognizes alpha-row letters across all layouts', () => {
+  // QWERTY right rows
+  expect(isAlphaLetter('y')).toBe(true)
+  expect(isAlphaLetter('h')).toBe(true)
+  expect(isAlphaLetter('n')).toBe(true)
+  // QWERTY left (via flipMap values)
+  expect(isAlphaLetter('t')).toBe(true)
+  expect(isAlphaLetter('a')).toBe(true)
+  expect(isAlphaLetter('z')).toBe(true)
+  // Punctuation that participates in some layout's alpha row
+  expect(isAlphaLetter(';')).toBe(true)
+  expect(isAlphaLetter(',')).toBe(true)
+  expect(isAlphaLetter('/')).toBe(true)
+  expect(isAlphaLetter("'")).toBe(true)
+})
+
+test('isAlphaLetter rejects row-5 outer punctuation', () => {
+  // The bug from PR #87: keycapInfo() collapses row 5 → 4 for keycap profile
+  // reasons, so a row-based filter wrongly catches these letters.
+  expect(isAlphaLetter('[')).toBe(false)
+  expect(isAlphaLetter(']')).toBe(false)
+  expect(isAlphaLetter('{')).toBe(false)
+  expect(isAlphaLetter('}')).toBe(false)
+  expect(isAlphaLetter('\\')).toBe(false)
+})
+
+test('isAlphaLetter rejects number-row and F-row legends', () => {
+  expect(isAlphaLetter('1')).toBe(false)
+  expect(isAlphaLetter('5')).toBe(false)
+  expect(isAlphaLetter('F1')).toBe(false)
+})
+
+test('isAlphaLetter handles empty/undefined', () => {
+  expect(isAlphaLetter(undefined)).toBe(false)
+  expect(isAlphaLetter('')).toBe(false)
 })

--- a/src/lib/presentation/Alert.svelte
+++ b/src/lib/presentation/Alert.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  // Popover-style alerts. Mounted once in App.svelte; iterates the `alerts`
+  // store and renders each as a positioned popover next to its anchor
+  // element. Auto-dismisses after `durationMs` (default 10s) with a progress
+  // bar at the bottom; pause-on-hover gives the user time to read longer
+  // messages.
+
+  import { alerts } from '$lib/store'
+  import AlertPopover from './AlertPopover.svelte'
+</script>
+
+{#each $alerts as alert (alert.id)}
+  <AlertPopover {alert} />
+{/each}

--- a/src/lib/presentation/AlertPopover.svelte
+++ b/src/lib/presentation/AlertPopover.svelte
@@ -1,0 +1,227 @@
+<script lang="ts">
+  // One alert popover. Positions itself below + slightly left of its anchor
+  // element using getBoundingClientRect. Tracks a setTimeout for auto-dismiss
+  // and pauses both the timer and the progress-bar animation while the
+  // pointer is over the popover. Drops itself if the anchor leaves the DOM.
+
+  import { type AlertItem, dismissAlert } from '$lib/store'
+  import Icon from '$lib/presentation/Icon.svelte'
+  import { mdiAlertCircleOutline, mdiAlertOutline, mdiClose, mdiInformationOutline } from '@mdi/js'
+  import { fade } from 'svelte/transition'
+  import { onDestroy, onMount, tick } from 'svelte'
+
+  export let alert: AlertItem
+
+  $: duration = alert.durationMs ?? 10000
+  $: variant = alert.variant ?? 'info'
+  $: iconPath =
+    variant === 'warn'
+      ? mdiAlertOutline
+      : variant === 'error'
+      ? mdiAlertCircleOutline
+      : mdiInformationOutline
+
+  let popoverEl: HTMLElement
+  let top = 0
+  let left = 0
+  let visible = false
+  let paused = false
+  let dismissTimer: ReturnType<typeof setTimeout> | null = null
+  let remaining = duration
+  let pauseStart = 0
+  let anchorObserver: MutationObserver | null = null
+  let onResize: (() => void) | null = null
+
+  function reposition() {
+    if (!alert.anchor || !popoverEl) {
+      // Fallback: pin to top-right of viewport.
+      top = 16
+      left = window.innerWidth - popoverEl?.offsetWidth - 16
+      return
+    }
+    const r = alert.anchor.getBoundingClientRect()
+    // Place below the anchor, left-aligned with it (slight inset).
+    top = r.bottom + 8
+    left = r.left
+    // Keep within the viewport horizontally.
+    const w = popoverEl.offsetWidth
+    if (left + w > window.innerWidth - 8) left = window.innerWidth - 8 - w
+    if (left < 8) left = 8
+  }
+
+  function startTimer() {
+    if (duration <= 0) return
+    if (dismissTimer) clearTimeout(dismissTimer)
+    dismissTimer = setTimeout(() => dismissAlert(alert.id), remaining)
+  }
+
+  function onPointerEnter() {
+    paused = true
+    if (dismissTimer) {
+      clearTimeout(dismissTimer)
+      dismissTimer = null
+      pauseStart = performance.now()
+    }
+  }
+
+  function onPointerLeave() {
+    paused = false
+    if (pauseStart) remaining -= performance.now() - pauseStart
+    if (remaining < 0) remaining = 0
+    pauseStart = 0
+    startTimer()
+  }
+
+  onMount(() => {
+    visible = true
+    // Wait for popoverEl to bind, then position + start timer + listeners.
+    tick().then(() => {
+      reposition()
+      startTimer()
+
+      onResize = () => reposition()
+      window.addEventListener('resize', onResize)
+      window.addEventListener('scroll', onResize, true)
+
+      // Drop the alert if its anchor is removed from the DOM.
+      if (alert.anchor) {
+        anchorObserver = new MutationObserver(() => {
+          if (alert.anchor && !document.contains(alert.anchor)) dismissAlert(alert.id)
+        })
+        anchorObserver.observe(document.body, { childList: true, subtree: true })
+      }
+    })
+  })
+
+  onDestroy(() => {
+    if (dismissTimer) clearTimeout(dismissTimer)
+    if (anchorObserver) anchorObserver.disconnect()
+    if (onResize) {
+      window.removeEventListener('resize', onResize)
+      window.removeEventListener('scroll', onResize, true)
+    }
+  })
+</script>
+
+{#if visible}
+  <div
+    bind:this={popoverEl}
+    class="alert-popover {variant}"
+    class:alert-paused={paused}
+    style="top: {top}px; left: {left}px; --dur: {duration}ms;"
+    on:pointerenter={onPointerEnter}
+    on:pointerleave={onPointerLeave}
+    transition:fade={{ duration: 120 }}
+    role="status"
+  >
+    <div class="alert-body">
+      <Icon path={iconPath} size="20" class="alert-icon flex-none" />
+      <div class="text-sm">{alert.message}</div>
+      <button class="alert-close ml-2" on:click={() => dismissAlert(alert.id)} aria-label="Dismiss">
+        <Icon path={mdiClose} size="16" />
+      </button>
+    </div>
+    {#if duration > 0}
+      <div class="alert-progress" />
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .alert-popover {
+    position: fixed;
+    z-index: 100;
+    max-width: 24rem;
+    padding: 0.5rem 0.5rem 0.6rem 0.75rem;
+    border-radius: 0.375rem;
+    box-shadow: 0 4px 16px -4px rgba(0, 0, 0, 0.2);
+    background: rgb(254 232 240);
+    color: rgb(60 20 50);
+    border: 1px solid rgb(244 200 220);
+    overflow: hidden;
+  }
+  :global(.dark) .alert-popover {
+    background: rgb(80 28 56);
+    color: rgb(254 232 240);
+    border-color: rgb(120 50 90);
+  }
+  .alert-popover.warn {
+    background: rgb(254 240 220);
+    border-color: rgb(240 200 140);
+  }
+  :global(.dark) .alert-popover.warn {
+    background: rgb(96 56 12);
+    border-color: rgb(140 90 30);
+  }
+  .alert-popover.error {
+    background: rgb(254 226 226);
+    border-color: rgb(248 180 180);
+  }
+  :global(.dark) .alert-popover.error {
+    background: rgb(96 28 28);
+    border-color: rgb(160 60 60);
+  }
+
+  .alert-body {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  :global(.alert-icon) {
+    color: rgb(190 60 130);
+    margin-top: 1px;
+  }
+  .warn :global(.alert-icon) {
+    color: rgb(170 100 20);
+  }
+  .error :global(.alert-icon) {
+    color: rgb(190 50 50);
+  }
+
+  .alert-close {
+    appearance: none;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    padding: 2px;
+    border-radius: 3px;
+    opacity: 0.6;
+    color: inherit;
+  }
+  .alert-close:hover {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.05);
+  }
+  :global(.dark) .alert-close:hover {
+    background: rgba(255, 255, 255, 0.1);
+  }
+
+  .alert-progress {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 3px;
+    background: rgb(190 60 130);
+    transform-origin: left;
+    animation: alert-deplete var(--dur, 10s) linear forwards;
+  }
+  .warn .alert-progress {
+    background: rgb(200 130 30);
+  }
+  .error .alert-progress {
+    background: rgb(190 50 50);
+  }
+  .alert-paused .alert-progress {
+    animation-play-state: paused;
+  }
+  @keyframes alert-deplete {
+    from {
+      transform: scaleX(1);
+    }
+    to {
+      transform: scaleX(0);
+    }
+  }
+</style>

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -30,6 +30,38 @@ export const clickedKey = writable<number | null>(null)
 export const clickedVisualSide = writable<'left' | 'right' | 'unibody' | null>(null)
 export const lastKeycap = writable<number>(0)
 
+// --- Alerts -----------------------------------------------------------------
+//
+// A lightweight popover-alert system: callers `pushAlert({ message, anchor })`
+// from anywhere; `Alert.svelte` (mounted once in App.svelte) renders a
+// dismissible popover next to the anchor element with a 10s auto-dismiss
+// timer and a progress bar. Used by the layout dropdown to surface "missing
+// keys" warnings and "you've switched to Custom" hints without blocking the
+// page with a modal dialog.
+
+export interface AlertItem {
+  id: symbol
+  message: string
+  /** DOM element to anchor the popover next to (typically the Field that
+   *  triggered the alert). null disables anchoring (centered fallback). */
+  anchor: HTMLElement | null
+  variant?: 'info' | 'warn' | 'error'
+  /** Auto-dismiss after this many ms. Default 10000. Pass 0 to disable. */
+  durationMs?: number
+}
+
+export const alerts = writable<AlertItem[]>([])
+
+export function pushAlert(a: Omit<AlertItem, 'id'>): symbol {
+  const id = Symbol()
+  alerts.update(xs => [...xs, { id, durationMs: 10000, variant: 'info', ...a }])
+  return id
+}
+
+export function dismissAlert(id: symbol) {
+  alerts.update(xs => xs.filter(a => a.id !== id))
+}
+
 export const showGrid = writable(false)
 export const noWall = writable(false)
 export const noBase = writable(false)

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -20,6 +20,14 @@ export const openSelect = writable<symbol | null>(null)
 
 export const hoveredKey = writable<number | null>(null)
 export const clickedKey = writable<number | null>(null)
+/** Which visual half the user clicked, regardless of which cluster the click
+ *  resolves to in storage. In mirror form (only the right cluster is stored)
+ *  `clickedKey` resolves to a right-cluster key for either side, so the editor
+ *  needs this hint to flip its Letter input through the layout's flipMap when
+ *  the user is editing a left-side virtual key. Distinct from
+ *  `Viewer3D`'s local `clickedSide` (which reports the *resolved* cluster's
+ *  side via nthKey). */
+export const clickedVisualSide = writable<'left' | 'right' | 'unibody' | null>(null)
 export const lastKeycap = writable<number>(0)
 
 export const showGrid = writable(false)

--- a/src/lib/worker/config.cosmos.ts
+++ b/src/lib/worker/config.cosmos.ts
@@ -2,12 +2,12 @@ import ETrsf, { Constant, fullMirrorETrsf, type MatrixOptions, mirror } from '$l
 // import { deserialize } from 'src/routes/beta/lib/serialize'
 import { flippedKey } from '$lib/geometry/keycaps'
 import { decodeVariant, encodeVariant, PART_INFO, socketSize } from '$lib/geometry/socketsParts'
-import { DEFAULT_LAYOUT, type LayoutId } from '$lib/layouts'
+import { DEFAULT_LAYOUT, flipLetter, getLayout, isAlphaLetter, LAYOUT, type LayoutId, NAMED_LAYOUT_IDS, type NamedLayoutId } from '$lib/layouts'
 import { type ClusterName, type ClusterSide, type ClusterType, type Connector, decodeClusterFlags, encodeClusterFlags, type PartVariant, type ScrewFlags } from '$target/cosmosStructs'
 import type { Curvature } from '$target/proto/cosmos'
 import { Matrix4, Vector3 } from 'three'
 import { type AnyShell, curvature, type Cuttleform, type CuttleKey, decodeTuple, encodeTuple, type FullCuttleform, type Keycap, matrixToRPY, tupleToRot, tupleToXYZ } from './config'
-import { decodePartType, encodePartType, KEYBOARD_DEFAULTS } from './config.serialize'
+import { decodePartType, encodePartType, KEYBOARD_DEFAULTS, LETTERS } from './config.serialize'
 import Trsf from './modeling/transformation'
 import { capitalize, DefaultMap, objEntries, objKeys, sum, TallyMap, trimUndefined } from './util'
 
@@ -111,7 +111,6 @@ export type CosmosKeyboard =
     connectors: ConnectorMaybeCustom[]
     mirrorConnectors: boolean
     plate: Cuttleform['plate']
-    layout: LayoutId
   }
   & ScrewFlags
 
@@ -299,12 +298,12 @@ export function toFullCosmosConfig(conf: FullCuttleform, flipLeft = false): Cosm
   // This halves the URL size and gives better editing experience
   const rightFingers = kbd.clusters.find(c => c.side == 'right' && c.name == 'fingers')
   const leftFingers = kbd.clusters.find(c => c.side == 'left' && c.name == 'fingers')
-  if (rightFingers && leftFingers && stringifyCluster(mirrorCluster(rightFingers, true, kbd.layout)) == stringifyCluster(leftFingers)) {
+  if (rightFingers && leftFingers && stringifyCluster(mirrorCluster(rightFingers, kbd)) == stringifyCluster(leftFingers)) {
     kbd.clusters.splice(kbd.clusters.indexOf(leftFingers), 1)
   }
   const rightThumbs = kbd.clusters.find(c => c.side == 'right' && c.name == 'thumbs')
   const leftThumbs = kbd.clusters.find(c => c.side == 'left' && c.name == 'thumbs')
-  if (rightThumbs && leftThumbs && stringifyCluster(mirrorCluster(rightThumbs, true, kbd.layout)) == stringifyCluster(leftThumbs)) {
+  if (rightThumbs && leftThumbs && stringifyCluster(mirrorCluster(rightThumbs, kbd)) == stringifyCluster(leftThumbs)) {
     kbd.clusters.splice(kbd.clusters.indexOf(leftThumbs), 1)
   }
   sortClusters(kbd.clusters)
@@ -370,7 +369,6 @@ export function toCosmosConfig(conf: Cuttleform, side: 'left' | 'right' | 'unibo
         extensionRight: 8,
       },
     wristRestPosition: overrideWristRest ? KEYBOARD_DEFAULTS.wristRestPosition! : encodeTuple(wrOrigin.xyz().map(t => Math.round(t * 10))),
-    layout: DEFAULT_LAYOUT,
     clusters: side == 'unibody'
       ? [
         ...toCosmosClusters(filterUnibodySide(conf.keys, 'right'), 'right', globalProfile, globalPartType, globalCurvature, wrOriginInv),
@@ -378,7 +376,7 @@ export function toCosmosConfig(conf: Cuttleform, side: 'left' | 'right' | 'unibo
       ]
       : toCosmosClusters(conf.keys, side, globalProfile, globalPartType, globalCurvature, wrOriginInv),
   }
-  if (flipLeft && side == 'left') keyboard.clusters = keyboard.clusters.map(c => mirrorCluster(c, false, keyboard.layout))
+  if (flipLeft && side == 'left') keyboard.clusters = keyboard.clusters.map(c => mirrorCluster(c, keyboard, false))
   sortClusters(keyboard.clusters)
   return keyboard
 }
@@ -483,15 +481,15 @@ export function sideFromCosmosConfig(c: CosmosKeyboard, side: 'left' | 'right' |
     plate: c.plate,
   }
   const clusters: CosmosCluster[] = c.clusters.filter(c => side == 'unibody' || c.side == side)
-  if (side == 'left' && !c.clusters.find(c => c.side == 'left' && c.name == 'fingers')) clusters.unshift(mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'fingers')!, true, c.layout))
+  if (side == 'left' && !c.clusters.find(c => c.side == 'left' && c.name == 'fingers')) clusters.unshift(mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'fingers')!, c))
   if (side == 'unibody' && !c.clusters.find(c => c.side == 'left' && c.name == 'fingers')) {
     clusters.splice(
       2,
       0,
-      mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'fingers')!, true, c.layout),
+      mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'fingers')!, c),
     )
   }
-  if (side != 'right' && !c.clusters.find(c => c.side == 'left' && c.name == 'thumbs')) clusters.push(mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'thumbs')!, true, c.layout))
+  if (side != 'right' && !c.clusters.find(c => c.side == 'left' && c.name == 'thumbs')) clusters.push(mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'thumbs')!, c))
   // console.log('CLUSTERS', clusters)
   for (const clusterA of clusters) {
     for (const clusterB of clusterA.clusters) {
@@ -551,7 +549,7 @@ export function fromCosmosConfig(c: CosmosKeyboard, flipLeft = true): FullCuttle
 export function calcClusterTrsf(cluster: CosmosCluster, keeb: CosmosKeyboard) {
   if (cluster.name == 'fingers') return rotationPositionETrsf(cluster, false)
 
-  const fingerCluster = keeb.clusters.find(c => c.side == cluster.side && c.name == 'fingers') || mirrorCluster(keeb.clusters.find(c => c.name == 'fingers')!, true, keeb.layout)
+  const fingerCluster = keeb.clusters.find(c => c.side == cluster.side && c.name == 'fingers') || mirrorCluster(keeb.clusters.find(c => c.name == 'fingers')!, keeb)
   const fingerPos = rotationPositionETrsf(fingerCluster, false) || new ETrsf()
   const fingerPosInv = rotationPositionInvETrsf(fingerCluster) || new ETrsf()
   return (rotationPositionETrsf(cluster) || new ETrsf()).transformBy(fingerPosInv).transformBy(fingerPos)
@@ -915,7 +913,15 @@ function mirrorRotationTuple(t: bigint | undefined) {
   return encodeTuple([x, -y, -z])
 }
 
-export function mirrorCluster(clr: CosmosCluster, flipLetters = true, layout: LayoutId = DEFAULT_LAYOUT): CosmosCluster {
+/** Synthesize the left side of a (right-side) cluster.
+ *
+ *  `kbd` is needed to derive the layout (via `detectLayout`) — alpha-letter
+ *  flipping uses the layout's flipMap. Pass `undefined` at module-level call
+ *  sites (e.g. cached cluster libraries) where no kbd is in scope; the result
+ *  there falls back to QWERTY semantics, which is fine because those callers
+ *  erase letters before display anyway. */
+export function mirrorCluster(clr: CosmosCluster, kbd: CosmosKeyboard | undefined, flipLetters = true): CosmosCluster {
+  const layout = kbd ? detectLayout(kbd) : DEFAULT_LAYOUT
   return {
     ...clr,
     curvature: { ...clr.curvature },
@@ -962,4 +968,105 @@ export function calculateSplay(column: CosmosCluster, cluster: CosmosCluster) {
 export function nthSplay(conf: CosmosKeyboard, n: number) {
   const { column, cluster } = nthKey(conf, n)
   return calculateSplay(column, cluster)
+}
+
+// --- Layout detection -------------------------------------------------------
+//
+// Layout used to be a stored field on CosmosKeyboard. It's now a pure function
+// of the alpha-key labels — like clusterAngle/clusterSeparation. detectLayout
+// inspects the right finger cluster and reports the named layout it matches,
+// or LAYOUT.CUSTOM. mirrorCluster() calls it internally so callers don't have
+// to thread the layout through.
+
+/** Canonical 5-col alpha block (Q-W-E-R-T row 2, A-S-D-F-G row 3, Z-X-C-V-B
+ *  row 4). All registered layouts share this width; an optional 6th outer-
+ *  pinky column (`'` in QWERTY/Colemak/Workman, `-` in Dvorak) is treated as
+ *  extra and doesn't participate in matching. */
+const STANDARD_ALPHA_COLS = 5
+
+/** Find the indices of the alpha/letter columns within a finger cluster.
+ *  Picks the up-to-5 columns with the most letter-keys; sorts by physical
+ *  column position (left → right). */
+export function alphaColumns(kbd: CosmosKeyboard, cluster: CosmosCluster) {
+  const columns = cluster.clusters.map((col, index) => ({
+    index,
+    column: col.column ?? -1000,
+    nLetters: col.keys
+      .filter(k => PART_INFO[k.partType.type || col.partType.type || kbd.partType.type!].keycap && LETTERS.includes(k.profile.letter!))
+      .length,
+  })).filter(c => c.nLetters > 0)
+  columns.sort((a, b) => b.nLetters - a.nLetters)
+  const topColumns = columns.slice(0, STANDARD_ALPHA_COLS)
+  return topColumns.sort((a, b) => a.column - b.column).map(c => c.index)
+}
+
+/** Inspect the right-finger alpha block and return the named layout it
+ *  matches one-for-one, or `LAYOUT.CUSTOM` if no named layout fits. Match
+ *  rules:
+ *    - At least STANDARD_ALPHA_COLS alpha columns required (else CUSTOM).
+ *    - Positions [0, STANDARD_ALPHA_COLS) on rows 2/3/4 must agree with the
+ *      candidate layout's right-side letters (left clusters compare against
+ *      the layout's flipMap-mirrored letters).
+ *    - Extra alpha columns past the canonical block are ignored. */
+export function detectLayout(kbd: CosmosKeyboard): LayoutId {
+  const cluster = kbd.clusters.find(c => c.name === 'fingers' && c.side === 'right')
+    ?? kbd.clusters.find(c => c.name === 'fingers')
+  if (!cluster) return DEFAULT_LAYOUT
+  const alphas = alphaColumns(kbd, cluster)
+  if (alphas.length < STANDARD_ALPHA_COLS) return LAYOUT.CUSTOM
+  const isLeft = cluster.side === 'left'
+
+  const observed: Record<2 | 3 | 4, (string | undefined)[]> = { 2: [], 3: [], 4: [] }
+  for (let i = 0; i < alphas.length; i++) {
+    const col = cluster.clusters[alphas[i]]
+    const letterCol = isLeft ? alphas.length - 1 - i : i
+    for (const row of [2, 3, 4] as const) {
+      const key = col.keys.find(k => k.profile.row === row && isAlphaLetter(k.profile.letter))
+      observed[row][letterCol] = key?.profile.letter
+    }
+  }
+
+  for (const id of NAMED_LAYOUT_IDS) {
+    const layout = getLayout(id)
+    if (
+      rowMatches(observed[2], layout.rightRows[2], isLeft, id)
+      && rowMatches(observed[3], layout.rightRows[3], isLeft, id)
+      && rowMatches(observed[4], layout.rightRows[4], isLeft, id)
+    ) {
+      return id
+    }
+  }
+  return LAYOUT.CUSTOM
+}
+
+function rowMatches(observed: (string | undefined)[], layoutRow: string, isLeft: boolean, layoutId: NamedLayoutId): boolean {
+  const upper = Math.min(STANDARD_ALPHA_COLS, layoutRow.length)
+  for (let col = 0; col < upper; col++) {
+    const expectedRight = layoutRow.charAt(col) || undefined
+    if (!expectedRight) continue
+    const expected = isLeft ? flipLetter(expectedRight, layoutId) : expectedRight
+    const observedLetter = observed[col]
+    if (!observedLetter || observedLetter !== expected) return false
+  }
+  return true
+}
+
+/** Letters the named layout requires that the keyboard can't currently host
+ *  (because the user removed columns down past STANDARD_ALPHA_COLS). Empty
+ *  when the kbd already has enough alpha columns. */
+export function missingKeysFor(kbd: CosmosKeyboard, target: NamedLayoutId): string[] {
+  const cluster = kbd.clusters.find(c => c.name === 'fingers' && c.side === 'right')
+    ?? kbd.clusters.find(c => c.name === 'fingers')
+  if (!cluster) return []
+  const have = alphaColumns(kbd, cluster).length
+  if (have >= STANDARD_ALPHA_COLS) return []
+  const layout = getLayout(target)
+  const missing: string[] = []
+  for (let col = have; col < STANDARD_ALPHA_COLS; col++) {
+    for (const row of [2, 3, 4] as const) {
+      const letter = layout.rightRows[row].charAt(col)
+      if (letter) missing.push(letter)
+    }
+  }
+  return missing
 }

--- a/src/lib/worker/config.cosmos.ts
+++ b/src/lib/worker/config.cosmos.ts
@@ -2,6 +2,7 @@ import ETrsf, { Constant, fullMirrorETrsf, type MatrixOptions, mirror } from '$l
 // import { deserialize } from 'src/routes/beta/lib/serialize'
 import { flippedKey } from '$lib/geometry/keycaps'
 import { decodeVariant, encodeVariant, PART_INFO, socketSize } from '$lib/geometry/socketsParts'
+import { DEFAULT_LAYOUT, type LayoutId } from '$lib/layouts'
 import { type ClusterName, type ClusterSide, type ClusterType, type Connector, decodeClusterFlags, encodeClusterFlags, type PartVariant, type ScrewFlags } from '$target/cosmosStructs'
 import type { Curvature } from '$target/proto/cosmos'
 import { Matrix4, Vector3 } from 'three'
@@ -110,6 +111,7 @@ export type CosmosKeyboard =
     connectors: ConnectorMaybeCustom[]
     mirrorConnectors: boolean
     plate: Cuttleform['plate']
+    layout: LayoutId
   }
   & ScrewFlags
 
@@ -297,12 +299,12 @@ export function toFullCosmosConfig(conf: FullCuttleform, flipLeft = false): Cosm
   // This halves the URL size and gives better editing experience
   const rightFingers = kbd.clusters.find(c => c.side == 'right' && c.name == 'fingers')
   const leftFingers = kbd.clusters.find(c => c.side == 'left' && c.name == 'fingers')
-  if (rightFingers && leftFingers && stringifyCluster(mirrorCluster(rightFingers)) == stringifyCluster(leftFingers)) {
+  if (rightFingers && leftFingers && stringifyCluster(mirrorCluster(rightFingers, true, kbd.layout)) == stringifyCluster(leftFingers)) {
     kbd.clusters.splice(kbd.clusters.indexOf(leftFingers), 1)
   }
   const rightThumbs = kbd.clusters.find(c => c.side == 'right' && c.name == 'thumbs')
   const leftThumbs = kbd.clusters.find(c => c.side == 'left' && c.name == 'thumbs')
-  if (rightThumbs && leftThumbs && stringifyCluster(mirrorCluster(rightThumbs)) == stringifyCluster(leftThumbs)) {
+  if (rightThumbs && leftThumbs && stringifyCluster(mirrorCluster(rightThumbs, true, kbd.layout)) == stringifyCluster(leftThumbs)) {
     kbd.clusters.splice(kbd.clusters.indexOf(leftThumbs), 1)
   }
   sortClusters(kbd.clusters)
@@ -368,6 +370,7 @@ export function toCosmosConfig(conf: Cuttleform, side: 'left' | 'right' | 'unibo
         extensionRight: 8,
       },
     wristRestPosition: overrideWristRest ? KEYBOARD_DEFAULTS.wristRestPosition! : encodeTuple(wrOrigin.xyz().map(t => Math.round(t * 10))),
+    layout: DEFAULT_LAYOUT,
     clusters: side == 'unibody'
       ? [
         ...toCosmosClusters(filterUnibodySide(conf.keys, 'right'), 'right', globalProfile, globalPartType, globalCurvature, wrOriginInv),
@@ -375,7 +378,7 @@ export function toCosmosConfig(conf: Cuttleform, side: 'left' | 'right' | 'unibo
       ]
       : toCosmosClusters(conf.keys, side, globalProfile, globalPartType, globalCurvature, wrOriginInv),
   }
-  if (flipLeft && side == 'left') keyboard.clusters = keyboard.clusters.map(c => mirrorCluster(c, false))
+  if (flipLeft && side == 'left') keyboard.clusters = keyboard.clusters.map(c => mirrorCluster(c, false, keyboard.layout))
   sortClusters(keyboard.clusters)
   return keyboard
 }
@@ -480,9 +483,15 @@ export function sideFromCosmosConfig(c: CosmosKeyboard, side: 'left' | 'right' |
     plate: c.plate,
   }
   const clusters: CosmosCluster[] = c.clusters.filter(c => side == 'unibody' || c.side == side)
-  if (side == 'left' && !c.clusters.find(c => c.side == 'left' && c.name == 'fingers')) clusters.unshift(mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'fingers')!))
-  if (side == 'unibody' && !c.clusters.find(c => c.side == 'left' && c.name == 'fingers')) clusters.splice(2, 0, mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'fingers')!))
-  if (side != 'right' && !c.clusters.find(c => c.side == 'left' && c.name == 'thumbs')) clusters.push(mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'thumbs')!))
+  if (side == 'left' && !c.clusters.find(c => c.side == 'left' && c.name == 'fingers')) clusters.unshift(mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'fingers')!, true, c.layout))
+  if (side == 'unibody' && !c.clusters.find(c => c.side == 'left' && c.name == 'fingers')) {
+    clusters.splice(
+      2,
+      0,
+      mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'fingers')!, true, c.layout),
+    )
+  }
+  if (side != 'right' && !c.clusters.find(c => c.side == 'left' && c.name == 'thumbs')) clusters.push(mirrorCluster(c.clusters.find(c => c.side == 'right' && c.name == 'thumbs')!, true, c.layout))
   // console.log('CLUSTERS', clusters)
   for (const clusterA of clusters) {
     for (const clusterB of clusterA.clusters) {
@@ -542,7 +551,7 @@ export function fromCosmosConfig(c: CosmosKeyboard, flipLeft = true): FullCuttle
 export function calcClusterTrsf(cluster: CosmosCluster, keeb: CosmosKeyboard) {
   if (cluster.name == 'fingers') return rotationPositionETrsf(cluster, false)
 
-  const fingerCluster = keeb.clusters.find(c => c.side == cluster.side && c.name == 'fingers') || mirrorCluster(keeb.clusters.find(c => c.name == 'fingers')!)
+  const fingerCluster = keeb.clusters.find(c => c.side == cluster.side && c.name == 'fingers') || mirrorCluster(keeb.clusters.find(c => c.name == 'fingers')!, true, keeb.layout)
   const fingerPos = rotationPositionETrsf(fingerCluster, false) || new ETrsf()
   const fingerPosInv = rotationPositionInvETrsf(fingerCluster) || new ETrsf()
   return (rotationPositionETrsf(cluster) || new ETrsf()).transformBy(fingerPosInv).transformBy(fingerPos)
@@ -906,7 +915,7 @@ function mirrorRotationTuple(t: bigint | undefined) {
   return encodeTuple([x, -y, -z])
 }
 
-export function mirrorCluster(clr: CosmosCluster, flipLetters = true): CosmosCluster {
+export function mirrorCluster(clr: CosmosCluster, flipLetters = true, layout: LayoutId = DEFAULT_LAYOUT): CosmosCluster {
   return {
     ...clr,
     curvature: { ...clr.curvature },
@@ -924,7 +933,7 @@ export function mirrorCluster(clr: CosmosCluster, flipLetters = true): CosmosClu
       column: typeof c.column != 'undefined' ? -c.column : undefined,
       keys: c.keys.map(k => ({
         ...k,
-        profile: { ...k.profile, letter: flipLetters ? flippedKey(k.profile.letter) : k.profile.letter },
+        profile: { ...k.profile, letter: flipLetters ? flippedKey(k.profile.letter, layout) : k.profile.letter },
         partType: { ...k.partType },
         column: typeof k.column != 'undefined' ? -k.column : undefined,
         position: mirrorPositionTuple(k.position),

--- a/src/lib/worker/config.serialize.ts
+++ b/src/lib/worker/config.serialize.ts
@@ -2,7 +2,7 @@
  * For now, the new serializationf format for Cosmos is kept in a separate file.
  */
 
-import { DEFAULT_LAYOUT, isLayoutId, LAYOUT_IDS, type LayoutId } from '$lib/layouts'
+import { DEFAULT_LAYOUT, type LayoutId } from '$lib/layouts'
 import { BinaryReader, BinaryWriter } from '@protobuf-ts/runtime'
 import {
   decodeBasicShellFlags,
@@ -40,16 +40,6 @@ import { objKeys } from './util'
 function lookupId<E>(items: readonly E[], id: number, msg: string) {
   if (id >= items.length || id < 0) throw new Error(`No ${msg} for id ${id}`)
   return items[id]
-}
-
-function encodeLayout(id: LayoutId): number {
-  const idx = LAYOUT_IDS.indexOf(id)
-  return idx < 0 ? 0 : idx
-}
-
-function decodeLayout(value: number | undefined): LayoutId {
-  const id = LAYOUT_IDS[value ?? 0]
-  return isLayoutId(id) ? id : DEFAULT_LAYOUT
 }
 
 export function encodePartType(key: PartType) {
@@ -224,7 +214,6 @@ export const KEYBOARD_DEFAULTS: Keyboard = {
   nScrews: 7,
   screwFlags: encodeScrewFlags({ screwSize: 'M3', screwType: 'screw insert', screwCountersink: true, clearScrews: true }),
   microcontroller: encodeMicrocontroller({ microcontroller: 'kb2040-adafruit', fastenMicrocontroller: true }),
-  layout: 0, // QWERTY
   roundedFlags: encodeRoundedFlags({ side: false, top: false }),
   keyboardFlags: encodeKeyboardFlags({ wrEnable: true, unibody: false, noMirrorConnectors: false }),
   wristRestPosition: encodeTuple([100, -1100, 0]),
@@ -532,7 +521,6 @@ export function decodeConfigIdk(b64: string): CosmosKeyboard {
     connectorLeftIndex: keebExtra.connectorLeftIndex / 10,
     connectorRightIndex: keebExtra.connectorRightIndex / 10,
     clusters: keeb.cluster.map(decodeCosmosCluster),
-    layout: decodeLayout(keeb.layout),
     plate: hasSpecialPlate
       ? {
         art: decodePlateArt(keebExtra.plateArt) || undefined,
@@ -714,7 +702,6 @@ export function encodeCosmosConfig(conf: CosmosKeyboard): Keyboard {
     roundedFlags: encodeRoundedFlags({ side: !!conf.rounded.side, top: !!conf.rounded.top }),
     keyboardFlags: encodeKeyboardFlags({ wrEnable: conf.wristRestEnable, unibody: conf.unibody, noMirrorConnectors: !conf.mirrorConnectors }),
     wristRestPosition: conf.wristRestPosition,
-    layout: encodeLayout(conf.layout ?? DEFAULT_LAYOUT),
     cluster: conf.clusters.map(encodeCosmosCluster),
     shell: encodeShell(conf.shell),
     extra: {

--- a/src/lib/worker/config.serialize.ts
+++ b/src/lib/worker/config.serialize.ts
@@ -2,6 +2,7 @@
  * For now, the new serializationf format for Cosmos is kept in a separate file.
  */
 
+import { DEFAULT_LAYOUT, isLayoutId, LAYOUT_IDS, type LayoutId } from '$lib/layouts'
 import { BinaryReader, BinaryWriter } from '@protobuf-ts/runtime'
 import {
   decodeBasicShellFlags,
@@ -39,6 +40,16 @@ import { objKeys } from './util'
 function lookupId<E>(items: readonly E[], id: number, msg: string) {
   if (id >= items.length || id < 0) throw new Error(`No ${msg} for id ${id}`)
   return items[id]
+}
+
+function encodeLayout(id: LayoutId): number {
+  const idx = LAYOUT_IDS.indexOf(id)
+  return idx < 0 ? 0 : idx
+}
+
+function decodeLayout(value: number | undefined): LayoutId {
+  const id = LAYOUT_IDS[value ?? 0]
+  return isLayoutId(id) ? id : DEFAULT_LAYOUT
 }
 
 export function encodePartType(key: PartType) {
@@ -213,6 +224,7 @@ export const KEYBOARD_DEFAULTS: Keyboard = {
   nScrews: 7,
   screwFlags: encodeScrewFlags({ screwSize: 'M3', screwType: 'screw insert', screwCountersink: true, clearScrews: true }),
   microcontroller: encodeMicrocontroller({ microcontroller: 'kb2040-adafruit', fastenMicrocontroller: true }),
+  layout: 0, // QWERTY
   roundedFlags: encodeRoundedFlags({ side: false, top: false }),
   keyboardFlags: encodeKeyboardFlags({ wrEnable: true, unibody: false, noMirrorConnectors: false }),
   wristRestPosition: encodeTuple([100, -1100, 0]),
@@ -520,6 +532,7 @@ export function decodeConfigIdk(b64: string): CosmosKeyboard {
     connectorLeftIndex: keebExtra.connectorLeftIndex / 10,
     connectorRightIndex: keebExtra.connectorRightIndex / 10,
     clusters: keeb.cluster.map(decodeCosmosCluster),
+    layout: decodeLayout(keeb.layout),
     plate: hasSpecialPlate
       ? {
         art: decodePlateArt(keebExtra.plateArt) || undefined,
@@ -701,6 +714,7 @@ export function encodeCosmosConfig(conf: CosmosKeyboard): Keyboard {
     roundedFlags: encodeRoundedFlags({ side: !!conf.rounded.side, top: !!conf.rounded.top }),
     keyboardFlags: encodeKeyboardFlags({ wrEnable: conf.wristRestEnable, unibody: conf.unibody, noMirrorConnectors: !conf.mirrorConnectors }),
     wristRestPosition: conf.wristRestPosition,
+    layout: encodeLayout(conf.layout ?? DEFAULT_LAYOUT),
     cluster: conf.clusters.map(encodeCosmosCluster),
     shell: encodeShell(conf.shell),
     extra: {

--- a/src/lib/worker/config.ts
+++ b/src/lib/worker/config.ts
@@ -1,5 +1,6 @@
 import type manuform from '$assets/manuform.json'
 import { socketSize } from '$lib/geometry/socketsParts'
+import { DEFAULT_LAYOUT, type LayoutId, rightSideLetter } from '$lib/layouts'
 import type { CuttleKey, CuttleTrackpadCirqueKey, MicrocontrollerName } from '$target/cosmosStructs'
 import {
   CONNECTOR,
@@ -513,19 +514,14 @@ function mergedCurvature(c: CuttleformProto, pinky: boolean, curv: any): any {
   }
 }
 
-function letterForKeycap(row: number, column: number) {
-  let letter = {
-    1: '67890',
-    2: 'yuiop',
-    3: "hjkl;'",
-    4: 'nm,./',
-    5: '{}[]\\',
-  }[row]?.charAt(column) || undefined
-  if (row == 0) letter = ['F6', 'F7', 'F8', 'F9', 'F10'][column] || undefined
-  return letter
+function letterForKeycap(row: number, column: number, layout: LayoutId = DEFAULT_LAYOUT) {
+  if (row == 0) return ['F6', 'F7', 'F8', 'F9', 'F10'][column] || undefined
+  if (row == 1) return '67890'.charAt(column) || undefined
+  if (row == 5) return '{}[]\\'.charAt(column) || undefined
+  return rightSideLetter(row, column, layout)
 }
 
-function keycapInfo(c: CuttleformProto, row: number, column: number): Keycap {
+function keycapInfo(c: CuttleformProto, row: number, column: number, layout: LayoutId = DEFAULT_LAYOUT): Keycap {
   let home: Keycap['home']
   if (row == 3) {
     home = ({
@@ -539,7 +535,7 @@ function keycapInfo(c: CuttleformProto, row: number, column: number): Keycap {
   // Row 5 is used for thumb keys (in MT3, the 5th row key has zero tilt)
   // So don't use it for the non-thumb keys since it is special!
   // (hence the Math.min(x, 4)
-  return { profile: keycapType(c), row: Math.min(row, 4), home, letter: letterForKeycap(row, column) }
+  return { profile: keycapType(c), row: Math.min(row, 4), home, letter: letterForKeycap(row, column, layout) }
 }
 
 export function decodeTuple(tuple: bigint): [number, number, number, number] {
@@ -602,7 +598,7 @@ export function tupleToXYZ(tuple: bigint) {
   return [decoded[0] / 10, decoded[1] / 10, decoded[2] / 10] as Point
 }
 
-export function cosmosFingers(nRows: number, nCols: number, side: 'left' | 'right', addExtraRow = true): CosmosCluster[] {
+export function cosmosFingers(nRows: number, nCols: number, side: 'left' | 'right', addExtraRow = true, layout: LayoutId = DEFAULT_LAYOUT): CosmosCluster[] {
   let columns = range(0, nCols)
   if (nCols <= 4) columns = range(1, nCols + 1)
   const rows = range(0, nRows)
@@ -650,7 +646,7 @@ export function cosmosFingers(nRows: number, nCols: number, side: 'left' | 'righ
             4: 'pinky',
           } as Record<number, Keycap['home']>)[column] ?? null
           : null,
-        letter: letterForKeycap(row2Row(row), column),
+        letter: letterForKeycap(row2Row(row), column, layout),
       },
       row: row - centerRow,
       position: undefined,

--- a/src/model_gen/loader.js
+++ b/src/model_gen/loader.js
@@ -5,6 +5,7 @@
  * as well as getting the extensions correct.
  */
 
+import { statSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
 import * as tsConfigPaths from 'tsconfig-paths'
 // @ts-ignore: Tyescript doesn't recognize ts-node/esm/transpile-only
@@ -24,7 +25,10 @@ export function resolve(specifier, context, defaultResolver) {
   if (mappedSpecifier) {
     // On Windows, Node.js expects absolute paths to be file:// urls
     // mappedSpecifier is an absolute path
-    const url = pathToFileURL(mappedSpecifier).href
+    // tsconfig-paths returns directory paths verbatim, so resolve `foo` →
+    // `foo/index` when `foo` is a directory before appending the extension.
+    const resolvedPath = isDirectory(mappedSpecifier) ? `${mappedSpecifier}/index` : mappedSpecifier
+    const url = pathToFileURL(resolvedPath).href
     specifier = url.endsWith('.json') ? url : `${url}.js`
   } else if (
     !specifier.endsWith('.ts') && !specifier.endsWith('.js')
@@ -35,6 +39,15 @@ export function resolve(specifier, context, defaultResolver) {
   }
   if (specifier.includes('$assets')) throw new Error(matchPath(specifier.replace('?url', '')))
   return resolveTs(specifier, context, defaultResolver)
+}
+
+/** @param {string} absPath */
+function isDirectory(absPath) {
+  try {
+    return statSync(absPath).isDirectory()
+  } catch {
+    return false
+  }
 }
 
 // @ts-ignore

--- a/src/proto/cosmos.proto
+++ b/src/proto/cosmos.proto
@@ -23,7 +23,16 @@ message Keyboard {
 
   optional KeyboardExtra extra = 14;
   optional int64 wrist_rest_position = 15; // For easy movement of the wrist rest
-  optional uint32 layout = 33; // Keyboard layout (QWERTY, Colemak, etc.). 0 = QWERTY default.
+
+  // Field 33 was a serialized layout id (QWERTY/Colemak/etc.). Layout is now
+  // derived purely from the alpha-key labels via detectLayout(kbd) at read
+  // time, like clusterAngle/clusterSeparation. Reserve so the field number
+  // can't be repurposed; old URLs that include it are silently ignored on
+  // decode. The cosmetic fallout is acceptable: a kbd serialized as
+  // "Colemak" with QWERTY letters baked in (shouldn't happen, since
+  // applyLayoutToKeys writes the letters whenever the dropdown changes) will
+  // now show up as QWERTY — the dropdown was lying before.
+  reserved 33;
 
   oneof shell {
     BasicShell basic_shell = 30;

--- a/src/proto/cosmos.proto
+++ b/src/proto/cosmos.proto
@@ -23,6 +23,7 @@ message Keyboard {
 
   optional KeyboardExtra extra = 14;
   optional int64 wrist_rest_position = 15; // For easy movement of the wrist rest
+  optional uint32 layout = 33; // Keyboard layout (QWERTY, Colemak, etc.). 0 = QWERTY default.
 
   oneof shell {
     BasicShell basic_shell = 30;

--- a/src/routes/beta/App.svelte
+++ b/src/routes/beta/App.svelte
@@ -24,6 +24,7 @@
   import HandFitView from './lib/dialogs/HandFitView.svelte'
   import Dialog from '$lib/presentation/Dialog.svelte'
   import Footer from './lib/Footer.svelte'
+  import Alert from '$lib/presentation/Alert.svelte'
   import Editor from './lib/editor/CodeEditor.svelte'
   import Preset from '$lib/presentation/Preset.svelte'
   import FilamentChart from './lib/FilamentChart.svelte'
@@ -1214,6 +1215,7 @@
 {/if} -->
 
 <DarkTheme bind:darkMode />
+<Alert />
 
 <style>
   @media (min-height: 480px) {

--- a/src/routes/beta/App.svelte
+++ b/src/routes/beta/App.svelte
@@ -544,6 +544,11 @@
         // CUSTOM when the keymap doesn't match any registered layout.
         next.layout = detectLayout(next)
         state.options = next
+        // Push into the proto store too — the basic-mode editor binds to
+        // $protoConfig, not state.options, so without this the dropdown and
+        // 3D view keep showing whatever was loaded before the expert edits.
+        protoConfig.set(next)
+        config = fromCosmosConfig(next)
         initialEditorContent = undefined // So the editor resets
       } catch (e) {
         console.error(e)

--- a/src/routes/beta/App.svelte
+++ b/src/routes/beta/App.svelte
@@ -66,6 +66,7 @@
   import ViewerDev from './lib/viewers/ViewerDev.svelte'
   import DownloadDialog from './lib/dialogs/DownloadDialog.svelte'
   import { fromCosmosConfig, toFullCosmosConfig, type CosmosKeyboard } from '$lib/worker/config.cosmos'
+  import { detectLayout } from './lib/editor/visualEditorHelpers'
   import KeyboardModel from '$lib/3d/KeyboardModel.svelte'
   import { type FullGeometry, type FullKeyboardMeshes } from './lib/viewers/viewer3dHelpers'
   import { notNull, objEntriesNotNull, objKeys } from '$lib/worker/util'
@@ -536,7 +537,13 @@
     if (mode === 'advanced' && newMode !== 'advanced') {
       // if (!confirm('Are you sure you wish to exit expert mode? Your work will not be saved.')) return
       try {
-        state.options = toFullCosmosConfig(config, true)
+        const next = toFullCosmosConfig(config, true)
+        // Recompute the layout from the keys themselves so the dropdown
+        // doesn't snap back to QWERTY when the user already designed a
+        // Colemak/Dvorak/etc. keymap in expert mode. Falls through to
+        // CUSTOM when the keymap doesn't match any registered layout.
+        next.layout = detectLayout(next)
+        state.options = next
         initialEditorContent = undefined // So the editor resets
       } catch (e) {
         console.error(e)

--- a/src/routes/beta/App.svelte
+++ b/src/routes/beta/App.svelte
@@ -66,7 +66,6 @@
   import ViewerDev from './lib/viewers/ViewerDev.svelte'
   import DownloadDialog from './lib/dialogs/DownloadDialog.svelte'
   import { fromCosmosConfig, toFullCosmosConfig, type CosmosKeyboard } from '$lib/worker/config.cosmos'
-  import { detectLayout } from './lib/editor/visualEditorHelpers'
   import KeyboardModel from '$lib/3d/KeyboardModel.svelte'
   import { type FullGeometry, type FullKeyboardMeshes } from './lib/viewers/viewer3dHelpers'
   import { notNull, objEntriesNotNull, objKeys } from '$lib/worker/util'
@@ -538,15 +537,13 @@
       // if (!confirm('Are you sure you wish to exit expert mode? Your work will not be saved.')) return
       try {
         const next = toFullCosmosConfig(config, true)
-        // Recompute the layout from the keys themselves so the dropdown
-        // doesn't snap back to QWERTY when the user already designed a
-        // Colemak/Dvorak/etc. keymap in expert mode. Falls through to
-        // CUSTOM when the keymap doesn't match any registered layout.
-        next.layout = detectLayout(next)
         state.options = next
         // Push into the proto store too — the basic-mode editor binds to
         // $protoConfig, not state.options, so without this the dropdown and
         // 3D view keep showing whatever was loaded before the expert edits.
+        // The layout dropdown re-derives its value from $protoConfig via
+        // detectLayout() at render time, so no explicit field write is
+        // needed here.
         protoConfig.set(next)
         config = fromCosmosConfig(next)
         initialEditorContent = undefined // So the editor resets

--- a/src/routes/beta/lib/dialogs/HandFitView.svelte
+++ b/src/routes/beta/lib/dialogs/HandFitView.svelte
@@ -93,7 +93,7 @@
             setStaggersCluster(leftSide, staggerLeft, true)
           } else {
             // Mirror the right cluster to the left, then set its size
-            const newLeftSide = mirrorCluster(rightSide!)
+            const newLeftSide = mirrorCluster(rightSide!, true, c.layout)
             setStaggersCluster(newLeftSide, staggerLeft, true)
             c.clusters.splice(2, 0, newLeftSide)
           }

--- a/src/routes/beta/lib/dialogs/HandFitView.svelte
+++ b/src/routes/beta/lib/dialogs/HandFitView.svelte
@@ -93,7 +93,7 @@
             setStaggersCluster(leftSide, staggerLeft, true)
           } else {
             // Mirror the right cluster to the left, then set its size
-            const newLeftSide = mirrorCluster(rightSide!, true, c.layout)
+            const newLeftSide = mirrorCluster(rightSide!, c)
             setStaggersCluster(newLeftSide, staggerLeft, true)
             c.clusters.splice(2, 0, newLeftSide)
           }

--- a/src/routes/beta/lib/editor/PeaConfig.svelte
+++ b/src/routes/beta/lib/editor/PeaConfig.svelte
@@ -7,7 +7,7 @@
   import { mapObjNotNull } from '$lib/worker/util'
   import { downloadQMKCode, type QMKOptions } from '../firmware/qmk'
   import type { FullGeometry } from '../viewers/viewer3dHelpers'
-  import { downloadZMKCode, type ZMKOptions } from '../firmware/zmk'
+  import { downloadZMKCode, Microcontroller, SplitTransport, type ZMKOptions } from '../firmware/zmk'
   import { downloadVia } from '../firmware/via'
   import Checkbox from '$lib/presentation/Checkbox.svelte'
   import { encoderKeys, type Matrix } from '../firmware/firmwareHelpers'
@@ -33,7 +33,7 @@
     wiredVersion: 'v0.4',
     wirelessVersion: 'v0.3',
     firmware: 'qmk',
-    splitTransport: 'uart',
+    splitTransport: SplitTransport.PioUsb,
   })
   $: fullOptions = {
     ...$options,
@@ -44,17 +44,17 @@
       cirque: c.keys.some((k) => k.type == 'trackpad-cirque'),
       encoder: !!encoderKeys(c).length,
     })),
-    microcontroller: anyConfig.microcontroller as 'lemon-wired' | 'lemon-wireless',
+    microcontroller: anyConfig.microcontroller as Microcontroller,
     // Phase 1 wired ZMK has no working WS2812 driver yet, so force underglow
     // off regardless of the user's preference; revisit when a PIO ws2812
     // binding lands in the fork.
-    ...(anyConfig.microcontroller === 'lemon-wired' && $options.firmware === 'zmk'
+    ...(anyConfig.microcontroller === Microcontroller.LemonWired && $options.firmware === 'zmk'
       ? { underGlowAtStart: false }
       : {}),
   } satisfies Partial<QMKOptions | ZMKOptions>
 
   $: anyConfig = config.right || config.unibody || { microcontroller: undefined }
-  $: truncated = anyConfig.microcontroller == 'lemon-wireless' && $modelName.length > 16
+  $: truncated = anyConfig.microcontroller == Microcontroller.LemonWireless && $modelName.length > 16
 </script>
 
 <p class="mt-4 mb-2">Successfully made the matrix!</p>
@@ -69,11 +69,11 @@
   </div>
 {/if}
 
-{#if anyConfig.microcontroller == 'lemon-wired'}
+{#if anyConfig.microcontroller == Microcontroller.LemonWired}
   <Field
     name="Firmware"
     icon="firmware"
-    help="QMK is the mature path. ZMK on the Lemon Wired is in Phase 1 — UART split over the Link port; no RGB underglow yet."
+    help="QMK is the mature path. ZMK on the Lemon Wired is in Phase 2 — Pico-PIO-USB split over the Link port; no RGB underglow yet."
   >
     <Select bind:value={$options.firmware}>
       <option value="qmk">QMK</option>
@@ -111,11 +111,11 @@
     <Field
       name="Split Transport"
       icon="version"
-      help="Phase 1 only ships UART over the Link port. Pico-PIO-USB is planned for Phase 2."
+      help="Pico-PIO-USB drives a USB-C cable between the two halves over the Link port (recommended). UART is the legacy path."
     >
       <Select bind:value={$options.splitTransport}>
-        <option value="uart">UART (Phase 1, recommended)</option>
-        <option value="pio-usb" disabled>Pico-PIO-USB (Phase 2)</option>
+        <option value={SplitTransport.PioUsb}>Pico-PIO-USB (recommended)</option>
+        <option value={SplitTransport.Uart}>UART (legacy)</option>
       </Select>
     </Field>
     <Field name="Enable ZMK Studio" icon="studio">
@@ -128,9 +128,11 @@
       >Download ZMK code</button
     >
     <InfoBox class="mt-4">
-      ZMK on the Lemon Wired is Phase 1 — UART split over the Link USB-C port (GP0/GP1). RGB underglow is
-      not yet supported on this MCU; it will return once a PIO-driven WS2812 binding lands in the fork.
-      Build with <code class="font-mono text-0.9em">west build -b cosmos_lemon_wired</code>.
+      ZMK on the Lemon Wired is Phase 2 — Pico-PIO-USB carries the split protocol over a USB-C cable
+      between the Link ports of both halves. Plug the central (PC-facing) half's native USB-C into your
+      computer; connect the central's Link to the peripheral's native USB-C. RGB underglow is not yet
+      supported on this MCU; it will return once a PIO-driven WS2812 binding lands in the fork. Build
+      with <code class="font-mono text-0.9em">west build -b cosmos_lemon_wired</code>.
     </InfoBox>
   {:else}
     <Field
@@ -159,7 +161,7 @@
     >. If there is no bootmagic key, you will need to double-tap the reset button.
   </div>
 {/if}
-{#if anyConfig.microcontroller == 'lemon-wireless'}
+{#if anyConfig.microcontroller == Microcontroller.LemonWireless}
   <Field name="Diode Direction" icon="diode-direction">
     <Select bind:value={$options.diodeDirection}>
       <option value="ROW2COL">ROW2COL (Pumpkin and Plum Twists)</option>

--- a/src/routes/beta/lib/editor/PeaConfig.svelte
+++ b/src/routes/beta/lib/editor/PeaConfig.svelte
@@ -20,7 +20,7 @@
   type OptionsType = Omit<
     QMKOptions & ZMKOptions,
     'keyboardName' | 'folderName' | 'peripherals' | 'microcontroller'
-  >
+  > & { firmware: 'qmk' | 'zmk' }
   const options = storable<OptionsType>('programmingOptions', {
     vid: '0x0001',
     pid: '0x0001',
@@ -32,6 +32,8 @@
     enableStudio: true,
     wiredVersion: 'v0.4',
     wirelessVersion: 'v0.3',
+    firmware: 'qmk',
+    splitTransport: 'uart',
   })
   $: fullOptions = {
     ...$options,
@@ -42,6 +44,13 @@
       cirque: c.keys.some((k) => k.type == 'trackpad-cirque'),
       encoder: !!encoderKeys(c).length,
     })),
+    microcontroller: anyConfig.microcontroller as 'lemon-wired' | 'lemon-wireless',
+    // Phase 1 wired ZMK has no working WS2812 driver yet, so force underglow
+    // off regardless of the user's preference; revisit when a PIO ws2812
+    // binding lands in the fork.
+    ...(anyConfig.microcontroller === 'lemon-wired' && $options.firmware === 'zmk'
+      ? { underGlowAtStart: false }
+      : {}),
   } satisfies Partial<QMKOptions | ZMKOptions>
 
   $: anyConfig = config.right || config.unibody || { microcontroller: undefined }
@@ -61,34 +70,83 @@
 {/if}
 
 {#if anyConfig.microcontroller == 'lemon-wired'}
+  <Field
+    name="Firmware"
+    icon="firmware"
+    help="QMK is the mature path. ZMK on the Lemon Wired is in Phase 1 — UART split over the Link port; no RGB underglow yet."
+  >
+    <Select bind:value={$options.firmware}>
+      <option value="qmk">QMK</option>
+      <option value="zmk">ZMK (Phase 1, experimental)</option>
+    </Select>
+  </Field>
   <Field name="Diode Direction" icon="diode-direction">
     <Select bind:value={$options.diodeDirection}>
       <option value="ROW2COL">ROW2COL (Pumpkin and Plum Twists)</option>
       <option value="COL2ROW">COL2ROW (Skree Flex PCBs)</option>
     </Select>
   </Field>
-  <Field name="Manufacturer Name (for USB)" icon="person">
-    <input class="input px-2" bind:value={$options.yourName} />
-  </Field>
+  {#if $options.firmware === 'qmk'}
+    <Field name="Manufacturer Name (for USB)" icon="person">
+      <input class="input px-2" bind:value={$options.yourName} />
+    </Field>
+  {/if}
   <Field name="Microcontroller Version" icon="version">
     <Select bind:value={$options.wiredVersion}>
       <option value="v0.4">v0.4</option>
       <option value="v0.5">v0.5</option>
     </Select>
   </Field>
-  <Field
-    name="Enable Console Debugging"
-    icon="debug"
-    help="Shows matrix and split debug information when you run qmk console"
-  >
-    <Checkbox bind:value={$options.enableConsole} />
-  </Field>
-  <button class="button" on:click={() => downloadQMKCode(geometry, matrix, fullOptions)}
-    >Download QMK code</button
-  >
-  <button class="button" on:click={() => downloadVia(geometry, matrix, fullOptions)}
-    >Download Via config</button
-  >
+  {#if $options.firmware === 'zmk'}
+    <Field
+      name="Central (Plug into PC) Side"
+      icon="pc"
+      help="Which half plugs into the computer. The other half talks to it over the Link USB-C port."
+    >
+      <Select bind:value={$options.centralSide}>
+        <option value="left">Left</option>
+        <option value="right">Right</option>
+      </Select>
+    </Field>
+    <Field
+      name="Split Transport"
+      icon="version"
+      help="Phase 1 only ships UART over the Link port. Pico-PIO-USB is planned for Phase 2."
+    >
+      <Select bind:value={$options.splitTransport}>
+        <option value="uart">UART (Phase 1, recommended)</option>
+        <option value="pio-usb" disabled>Pico-PIO-USB (Phase 2)</option>
+      </Select>
+    </Field>
+    <Field name="Enable ZMK Studio" icon="studio">
+      <Checkbox bind:value={$options.enableStudio} />
+    </Field>
+    <Field name="Enable USB Logging" icon="debug" help="Writes debug information to a USB serial port">
+      <Checkbox bind:value={$options.enableConsole} />
+    </Field>
+    <button class="button" on:click={() => downloadZMKCode(geometry, matrix, fullOptions)}
+      >Download ZMK code</button
+    >
+    <InfoBox class="mt-4">
+      ZMK on the Lemon Wired is Phase 1 — UART split over the Link USB-C port (GP0/GP1). RGB underglow is
+      not yet supported on this MCU; it will return once a PIO-driven WS2812 binding lands in the fork.
+      Build with <code class="font-mono text-0.9em">west build -b cosmos_lemon_wired</code>.
+    </InfoBox>
+  {:else}
+    <Field
+      name="Enable Console Debugging"
+      icon="debug"
+      help="Shows matrix and split debug information when you run qmk console"
+    >
+      <Checkbox bind:value={$options.enableConsole} />
+    </Field>
+    <button class="button" on:click={() => downloadQMKCode(geometry, matrix, fullOptions)}
+      >Download QMK code</button
+    >
+    <button class="button" on:click={() => downloadVia(geometry, matrix, fullOptions)}
+      >Download Via config</button
+    >
+  {/if}
 
   <div class="mt-4 text-gray-500 dark:text-gray-200">
     Read the <a class="text-pink-600 underline" href="{base}/docs/firmware/" target="_blank"

--- a/src/routes/beta/lib/editor/PeaConfig.svelte
+++ b/src/routes/beta/lib/editor/PeaConfig.svelte
@@ -17,7 +17,10 @@
   export let geometry: FullGeometry
   export let matrix: Matrix
 
-  type OptionsType = Omit<QMKOptions & ZMKOptions, 'keyboardName' | 'folderName' | 'peripherals'>
+  type OptionsType = Omit<
+    QMKOptions & ZMKOptions,
+    'keyboardName' | 'folderName' | 'peripherals' | 'microcontroller'
+  >
   const options = storable<OptionsType>('programmingOptions', {
     vid: '0x0001',
     pid: '0x0001',

--- a/src/routes/beta/lib/editor/SelectLayoutInner.svelte
+++ b/src/routes/beta/lib/editor/SelectLayoutInner.svelte
@@ -5,7 +5,6 @@
     flipLetter,
     getLayout,
     isNamedLayoutId,
-    LAYOUT,
     type LayoutId,
     type NamedLayoutId,
   } from '$lib/layouts'
@@ -89,24 +88,6 @@
             </div>
           {/each}
         </div>
-      {:else if option.key === LAYOUT.CUSTOM}
-        <div class="ortho mb-3" aria-hidden="true">
-          {#each [0, 1, 2] as r}
-            <div class="orow">
-              <div class="oside">
-                {#each Array(5) as _}
-                  <span class="ocell custom">?</span>
-                {/each}
-              </div>
-              <div class="ogap" />
-              <div class="oside">
-                {#each Array(5) as _}
-                  <span class="ocell custom">?</span>
-                {/each}
-              </div>
-            </div>
-          {/each}
-        </div>
       {/if}
       <p>{description}</p>
     </div>
@@ -130,10 +111,7 @@
     --at-apply: 'inline-flex items-center justify-center w-6 h-6 rounded bg-pink-50 dark:bg-pink-100 text-pink-900 font-mono text-xs border border-pink-300';
   }
   .ocell.home {
-    --at-apply: 'bg-pink-300 dark:bg-pink-300 border-pink-500';
-  }
-  .ocell.custom {
-    --at-apply: 'opacity-60 italic';
+    --at-apply: 'bg-pink-200 dark:bg-pink-200 border-pink-400';
   }
   :global(.layoutinfo p) {
     --at-apply: 'mb-1';

--- a/src/routes/beta/lib/editor/SelectLayoutInner.svelte
+++ b/src/routes/beta/lib/editor/SelectLayoutInner.svelte
@@ -20,11 +20,26 @@
   $: description = isNamedLayoutId(option.key) ? getLayout(option.key).description : CUSTOM_DESCRIPTION
   $: rightRows = isNamedLayoutId(option.key) ? getLayout(option.key).rightRows : null
 
-  // Mirror right-side row to left-side via the layout's flip map. Left col
-  // order is the kbd's physical order (pinky outer → index inner), which is
-  // the right row reversed and flipped.
-  function leftRow(row: string, layoutId: NamedLayoutId): string[] {
-    return [...row].reverse().map((ch) => flipLetter(ch, layoutId) ?? ch)
+  // Render exactly the canonical 5-column alpha block per side. Some layouts
+  // include a 6th outer-pinky character on the right (`'` in QWERTY/Colemak/
+  // Workman, `/` and `-` in Dvorak) that has no symmetric left-side equivalent
+  // in the flipMap, so showing it on the left would produce stray glyphs.
+  const ALPHA_COLS = 5
+
+  // The three alpha rows the layout defines (top, home, bottom). Typed as the
+  // literal union the rightRows record actually has, so {#each} lookups index
+  // it without TS complaining about `number`.
+  const ALPHA_ROWS: (2 | 3 | 4)[] = [2, 3, 4]
+
+  // Right side: first 5 chars in column-position order (index inner → pinky outer).
+  function rightCells(row: string): string[] {
+    return [...row.slice(0, ALPHA_COLS)]
+  }
+
+  // Left side: same 5 columns mirrored. Physical order is pinky outer → index
+  // inner, i.e. the right row reversed and flipped through the layout's map.
+  function leftCells(row: string, layoutId: NamedLayoutId): string[] {
+    return [...row.slice(0, ALPHA_COLS)].reverse().map((ch) => flipLetter(ch, layoutId) ?? ch)
   }
 
   const {
@@ -58,16 +73,16 @@
              with a gap representing the split. Three rows shown (top alpha,
              home, bottom alpha); home row highlighted. -->
         <div class="ortho mb-3" aria-hidden="true">
-          {#each [2, 3, 4] as row}
+          {#each ALPHA_ROWS as row}
             <div class="orow">
               <div class="oside">
-                {#each leftRow(rightRows[row], option.key) as ch}
+                {#each leftCells(rightRows[row], option.key) as ch}
                   <span class="ocell" class:home={row === 3}>{ch}</span>
                 {/each}
               </div>
               <div class="ogap" />
               <div class="oside">
-                {#each rightRows[row] as ch}
+                {#each rightCells(rightRows[row]) as ch}
                   <span class="ocell" class:home={row === 3}>{ch}</span>
                 {/each}
               </div>

--- a/src/routes/beta/lib/editor/SelectLayoutInner.svelte
+++ b/src/routes/beta/lib/editor/SelectLayoutInner.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import { createTooltip, melt } from '@melt-ui/svelte'
+  import { fade } from 'svelte/transition'
+  import {
+    flipLetter,
+    getLayout,
+    isNamedLayoutId,
+    LAYOUT,
+    type LayoutId,
+    type NamedLayoutId,
+  } from '$lib/layouts'
+
+  type Option = { key: LayoutId; label: string }
+
+  export let option: Option
+
+  const CUSTOM_DESCRIPTION =
+    "Your own layout — Cosmos won't auto-fill or overwrite key legends. Click a key in the 3D view and edit the Letter field to set custom legends per key."
+
+  $: description = isNamedLayoutId(option.key) ? getLayout(option.key).description : CUSTOM_DESCRIPTION
+  $: rightRows = isNamedLayoutId(option.key) ? getLayout(option.key).rightRows : null
+
+  // Mirror right-side row to left-side via the layout's flip map. Left col
+  // order is the kbd's physical order (pinky outer → index inner), which is
+  // the right row reversed and flipped.
+  function leftRow(row: string, layoutId: NamedLayoutId): string[] {
+    return [...row].reverse().map((ch) => flipLetter(ch, layoutId) ?? ch)
+  }
+
+  const {
+    elements: { trigger, content, arrow },
+    states: { open: tooltipOpen },
+  } = createTooltip({
+    positioning: { placement: 'right' },
+    openDelay: 0,
+    closeDelay: 0,
+    closeOnPointerDown: false,
+    forceVisible: true,
+    group: 'selectThingy',
+    escapeBehavior: 'defer-otherwise-close',
+  })
+</script>
+
+<div class="pl-6 py-0.25 pr-4" use:melt={$trigger}>
+  <span>{option.label}</span>
+</div>
+
+{#if $tooltipOpen}
+  <div
+    use:melt={$content}
+    transition:fade={{ duration: 50 }}
+    class="z-100 rounded-md bg-pink-200 dark:text-pink-950 shadow"
+  >
+    <div use:melt={$arrow} />
+    <div class="px-6 py-4 max-w-80 layoutinfo">
+      {#if rightRows && isNamedLayoutId(option.key)}
+        <!-- Split-ortholinear render: left and right alpha blocks side-by-side
+             with a gap representing the split. Three rows shown (top alpha,
+             home, bottom alpha); home row highlighted. -->
+        <div class="ortho mb-3" aria-hidden="true">
+          {#each [2, 3, 4] as row}
+            <div class="orow">
+              <div class="oside">
+                {#each leftRow(rightRows[row], option.key) as ch}
+                  <span class="ocell" class:home={row === 3}>{ch}</span>
+                {/each}
+              </div>
+              <div class="ogap" />
+              <div class="oside">
+                {#each rightRows[row] as ch}
+                  <span class="ocell" class:home={row === 3}>{ch}</span>
+                {/each}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {:else if option.key === LAYOUT.CUSTOM}
+        <div class="ortho mb-3" aria-hidden="true">
+          {#each [0, 1, 2] as r}
+            <div class="orow">
+              <div class="oside">
+                {#each Array(5) as _}
+                  <span class="ocell custom">?</span>
+                {/each}
+              </div>
+              <div class="ogap" />
+              <div class="oside">
+                {#each Array(5) as _}
+                  <span class="ocell custom">?</span>
+                {/each}
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+      <p>{description}</p>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .ortho {
+    --at-apply: 'flex flex-col items-center gap-1';
+  }
+  .orow {
+    --at-apply: 'flex items-center';
+  }
+  .oside {
+    --at-apply: 'flex gap-1';
+  }
+  .ogap {
+    --at-apply: 'w-4';
+  }
+  .ocell {
+    --at-apply: 'inline-flex items-center justify-center w-6 h-6 rounded bg-pink-50 dark:bg-pink-100 text-pink-900 font-mono text-xs border border-pink-300';
+  }
+  .ocell.home {
+    --at-apply: 'bg-pink-300 dark:bg-pink-300 border-pink-500';
+  }
+  .ocell.custom {
+    --at-apply: 'opacity-60 italic';
+  }
+  :global(.layoutinfo p) {
+    --at-apply: 'mb-1';
+  }
+</style>

--- a/src/routes/beta/lib/editor/VisualEditor2.svelte
+++ b/src/routes/beta/lib/editor/VisualEditor2.svelte
@@ -29,7 +29,7 @@
   import { TupleStore } from './tuple'
 
   import { createEventDispatcher } from 'svelte'
-  import { protoConfig, tempConfig } from '$lib/store'
+  import { protoConfig, pushAlert, tempConfig } from '$lib/store'
   import { hasPro } from '@pro'
   import {
     BOARD_PROPERTIES,
@@ -80,7 +80,6 @@
     toggleNumRow,
     toggleOuterCol,
   } from './visualEditorHelpers'
-  import { base } from '$app/paths'
   import {
     DEFAULT_LAYOUT,
     isLayoutId,
@@ -245,16 +244,14 @@
     }
   }
 
-  // Custom-layout dialogs (replaced with alerts in a follow-up commit).
-  let customInfoDialog = false
-  let missingKeysDialog: { target: NamedLayoutId; missing: string[] } | null = null
-
   // Layout is derived purely from the kbd's alpha labels — like clusterAngle
   // / clusterSeparation. The dropdown displays detectLayout($protoConfig);
   // picking a named option mutates the keys via applyLayoutToKeys. There's
   // no `kbd.layout` field to keep in sync, and no reactive auto-flip block
   // (the dropdown re-derives on every render).
   $: currentLayout = detectLayout($protoConfig)
+  // Anchor for layout-related alerts; bound to the Layout Field below.
+  let layoutFieldEl: HTMLElement
 
   function updateLayout(ev: CustomEvent<string>) {
     if (!isLayoutId(ev.detail)) return
@@ -262,10 +259,15 @@
     const prev = currentLayout
     if (next === prev) return
 
-    // Manual switch INTO Custom from a named layout — surface a helper dialog
+    // Manual switch INTO Custom from a named layout — pop a helper alert
     // explaining how to edit individual key legends.
     if (next === LAYOUT.CUSTOM && prev !== LAYOUT.CUSTOM) {
-      customInfoDialog = true
+      pushAlert({
+        message:
+          "You're now on Custom — Cosmos won't overwrite your key legends. To edit a single key, click it in the 3D view and edit the Letter field.",
+        anchor: layoutFieldEl,
+        variant: 'info',
+      })
       return // No kbd mutation — Custom is the absence of a named layout.
     }
 
@@ -276,7 +278,13 @@
     if (prev === LAYOUT.CUSTOM && next !== LAYOUT.CUSTOM) {
       const missing = missingKeysFor($protoConfig, next as NamedLayoutId)
       if (missing.length) {
-        missingKeysDialog = { target: next as NamedLayoutId, missing }
+        pushAlert({
+          message: `${LAYOUT_NAMES[next]} needs alpha keys you don't have: ${missing.join(
+            ' '
+          )}. Add them via the Inner/Outer column buttons under Cluster Size and try again.`,
+          anchor: layoutFieldEl,
+          variant: 'warn',
+        })
         return
       }
     }
@@ -606,19 +614,21 @@
       minWidth={200}
     />
   </Field>
-  <Field
-    name="Layout"
-    icon="letter"
-    help="The keyboard layout printed on the keycaps and used for firmware (ZMK/QMK) keycodes."
-  >
-    <SelectThingy
-      value={currentLayout}
-      on:change={updateLayout}
-      options={LAYOUT_IDS.map((id) => ({ key: id, label: LAYOUT_NAMES[id] }))}
-      component={SelectLayoutInner}
-      minWidth={320}
-    />
-  </Field>
+  <div bind:this={layoutFieldEl}>
+    <Field
+      name="Layout"
+      icon="letter"
+      help="The keyboard layout printed on the keycaps and used for firmware (ZMK/QMK) keycodes."
+    >
+      <SelectThingy
+        value={currentLayout}
+        on:change={updateLayout}
+        options={LAYOUT_IDS.map((id) => ({ key: id, label: LAYOUT_NAMES[id] }))}
+        component={SelectLayoutInner}
+        minWidth={320}
+      />
+    </Field>
+  </div>
   <Field name="Switches" icon="switch">
     <!-- <Select bind:value={$protoConfig.partType.type} on:change={updateSwitch}>
            {#each objKeys(PART_INFO).filter((k) => PART_INFO[k].category == 'Sockets' && k != 'blank') as part}
@@ -1492,43 +1502,6 @@
     <span slot="title">Set Size Exactly</span>
     <div slot="content">
       <SizeEditView on:size={(e) => setSize(e.detail[0] + 1, e.detail[1], false)} />
-    </div>
-  </Dialog>
-{/if}
-
-{#if customInfoDialog}
-  <Dialog small on:close={() => (customInfoDialog = false)}>
-    <span slot="title">Custom Layout</span>
-    <div slot="content">
-      <p class="mb-2">
-        You've switched to the <b>Custom</b> layout. Cosmos will keep whatever legends you set on each key
-        — it won't overwrite them with QWERTY/Colemak/etc.
-      </p>
-      <p class="mb-2">
-        To change a single key's legend, click the key in the 3D view and edit the <b>Letter</b> field in
-        the right panel. See
-        <a class="text-pink-600 underline" href="{base}/docs/basics/editor/#edit-key" target="_blank"
-          >the docs</a
-        > for a walkthrough.
-      </p>
-    </div>
-  </Dialog>
-{/if}
-
-{#if missingKeysDialog}
-  <Dialog small on:close={() => (missingKeysDialog = null)}>
-    <span slot="title">Missing keys for {LAYOUT_NAMES[missingKeysDialog.target]}</span>
-    <div slot="content">
-      <p class="mb-2">
-        Switching to <b>{LAYOUT_NAMES[missingKeysDialog.target]}</b> needs alpha keys you don't have:
-      </p>
-      <p class="mb-3 font-mono text-center text-lg">
-        {missingKeysDialog.missing.map((l) => `'${l}'`).join('  ')}
-      </p>
-      <p>
-        Add the missing alpha column(s) using the <b>Inner</b> or <b>Outer</b> buttons under
-        <b>Cluster Size</b>, then try the layout again.
-      </p>
     </div>
   </Dialog>
 {/if}

--- a/src/routes/beta/lib/editor/VisualEditor2.svelte
+++ b/src/routes/beta/lib/editor/VisualEditor2.svelte
@@ -38,8 +38,10 @@
     microcontrollerConnectors,
   } from '$lib/geometry/microcontrollers'
   import {
+    detectLayout,
     fromCosmosConfig,
     mirrorCluster,
+    missingKeysFor,
     partVariant,
     toCosmosConfig,
     type ConnectorMaybeCustom,
@@ -60,7 +62,6 @@
     clusterAngle,
     clusterSeparation,
     connectorsString,
-    detectLayout,
     getNKeys,
     getSize,
     getThumbN,
@@ -70,7 +71,6 @@
     isFnKey,
     isNumKey,
     isThumb,
-    missingKeysFor,
     setClusterAngle,
     setClusterSeparation,
     setClusterSize,
@@ -245,27 +245,34 @@
     }
   }
 
-  // Custom-layout dialogs.
+  // Custom-layout dialogs (replaced with alerts in a follow-up commit).
   let customInfoDialog = false
   let missingKeysDialog: { target: NamedLayoutId; missing: string[] } | null = null
+
+  // Layout is derived purely from the kbd's alpha labels — like clusterAngle
+  // / clusterSeparation. The dropdown displays detectLayout($protoConfig);
+  // picking a named option mutates the keys via applyLayoutToKeys. There's
+  // no `kbd.layout` field to keep in sync, and no reactive auto-flip block
+  // (the dropdown re-derives on every render).
+  $: currentLayout = detectLayout($protoConfig)
 
   function updateLayout(ev: CustomEvent<string>) {
     if (!isLayoutId(ev.detail)) return
     const next = ev.detail as LayoutId
-    const prev = $protoConfig.layout ?? DEFAULT_LAYOUT
+    const prev = currentLayout
     if (next === prev) return
 
     // Manual switch INTO Custom from a named layout — surface a helper dialog
     // explaining how to edit individual key legends.
     if (next === LAYOUT.CUSTOM && prev !== LAYOUT.CUSTOM) {
       customInfoDialog = true
+      return // No kbd mutation — Custom is the absence of a named layout.
     }
 
     // Switch OUT of Custom into a named layout — refuse if the keyboard
     // doesn't have enough alpha columns to host the target layout (the user
-    // probably deleted columns earlier). Don't commit to protoConfig; the
-    // SelectThingy dropdown is bound to $protoConfig.layout, so leaving the
-    // store value alone reverts the visual selection on the next tick.
+    // probably deleted columns earlier). Don't mutate the kbd; the dropdown
+    // re-derives via detectLayout and stays at Custom.
     if (prev === LAYOUT.CUSTOM && next !== LAYOUT.CUSTOM) {
       const missing = missingKeysFor($protoConfig, next as NamedLayoutId)
       if (missing.length) {
@@ -274,24 +281,7 @@
       }
     }
 
-    protoConfig.update((proto) => {
-      proto.layout = next
-      // CUSTOM has no letter mapping — picking it means "leave the keys alone";
-      // applyLayoutToKeys would silently rewrite letters with QWERTY's fallback.
-      if (next === LAYOUT.CUSTOM) return proto
-      return applyLayoutToKeys(proto, next)
-    })
-  }
-
-  // Auto-flip to Custom when the user edits an alpha legend (or removes an
-  // alpha column) so the dropdown doesn't keep claiming "Colemak" while the
-  // keymap diverges. Skip when current is already Custom — we don't auto-
-  // promote back to a named layout; the user picks that explicitly.
-  $: if ($protoConfig && ($protoConfig.layout ?? DEFAULT_LAYOUT) !== LAYOUT.CUSTOM) {
-    const detected = detectLayout($protoConfig)
-    if (detected === LAYOUT.CUSTOM) {
-      protoConfig.update((proto) => ({ ...proto, layout: LAYOUT.CUSTOM }))
-    }
+    protoConfig.update((proto) => applyLayoutToKeys(proto, next))
   }
 
   function updateSwitch(ev: CustomEvent) {
@@ -340,11 +330,7 @@
         proto.clusters.splice(
           cluster == 'fingers' ? 2 : 3,
           0,
-          mirrorCluster(
-            proto.clusters.find((c) => c.side == 'right' && c.name == cluster)!,
-            true,
-            proto.layout
-          )
+          mirrorCluster(proto.clusters.find((c) => c.side == 'right' && c.name == cluster)!, proto)
         )
       }
       return proto
@@ -626,7 +612,7 @@
     help="The keyboard layout printed on the keycaps and used for firmware (ZMK/QMK) keycodes."
   >
     <SelectThingy
-      value={$protoConfig.layout ?? DEFAULT_LAYOUT}
+      value={currentLayout}
       on:change={updateLayout}
       options={LAYOUT_IDS.map((id) => ({ key: id, label: LAYOUT_NAMES[id] }))}
       component={SelectLayoutInner}

--- a/src/routes/beta/lib/editor/VisualEditor2.svelte
+++ b/src/routes/beta/lib/editor/VisualEditor2.svelte
@@ -109,6 +109,7 @@
   import SelectProfileInner from './SelectProfileInner.svelte'
   import SelectProfileLabel from './SelectProfileLabel.svelte'
   import SelectMicrocontrollerInner from './SelectMicrocontrollerInner.svelte'
+  import SelectLayoutInner from './SelectLayoutInner.svelte'
   import { trackEvent } from '$lib/telemetry'
   import { footIndices } from '$lib/worker/geometry'
 
@@ -248,11 +249,11 @@
   let customInfoDialog = false
   let missingKeysDialog: { target: NamedLayoutId; missing: string[] } | null = null
 
-  function updateLayout(ev: Event) {
-    const target = ev.target as HTMLSelectElement
-    if (!isLayoutId(target.value)) return
-    const next = target.value as LayoutId
+  function updateLayout(ev: CustomEvent<string>) {
+    if (!isLayoutId(ev.detail)) return
+    const next = ev.detail as LayoutId
     const prev = $protoConfig.layout ?? DEFAULT_LAYOUT
+    if (next === prev) return
 
     // Manual switch INTO Custom from a named layout — surface a helper dialog
     // explaining how to edit individual key legends.
@@ -262,12 +263,13 @@
 
     // Switch OUT of Custom into a named layout — refuse if the keyboard
     // doesn't have enough alpha columns to host the target layout (the user
-    // probably deleted columns earlier).
+    // probably deleted columns earlier). Don't commit to protoConfig; the
+    // SelectThingy dropdown is bound to $protoConfig.layout, so leaving the
+    // store value alone reverts the visual selection on the next tick.
     if (prev === LAYOUT.CUSTOM && next !== LAYOUT.CUSTOM) {
       const missing = missingKeysFor($protoConfig, next as NamedLayoutId)
       if (missing.length) {
         missingKeysDialog = { target: next as NamedLayoutId, missing }
-        target.value = LAYOUT.CUSTOM // revert the dropdown to its current state
         return
       }
     }
@@ -623,11 +625,13 @@
     icon="letter"
     help="The keyboard layout printed on the keycaps and used for firmware (ZMK/QMK) keycodes."
   >
-    <Select value={$protoConfig.layout ?? DEFAULT_LAYOUT} on:change={updateLayout}>
-      {#each LAYOUT_IDS as id}
-        <option value={id}>{LAYOUT_NAMES[id]}</option>
-      {/each}
-    </Select>
+    <SelectThingy
+      value={$protoConfig.layout ?? DEFAULT_LAYOUT}
+      on:change={updateLayout}
+      options={LAYOUT_IDS.map((id) => ({ key: id, label: LAYOUT_NAMES[id] }))}
+      component={SelectLayoutInner}
+      minWidth={320}
+    />
   </Field>
   <Field name="Switches" icon="switch">
     <!-- <Select bind:value={$protoConfig.partType.type} on:change={updateSwitch}>

--- a/src/routes/beta/lib/editor/VisualEditor2.svelte
+++ b/src/routes/beta/lib/editor/VisualEditor2.svelte
@@ -56,6 +56,7 @@
   import { encodeVariant, PART_INFO } from '$lib/geometry/socketsParts'
   import DecimalInputInherit from './DecimalInputInherit.svelte'
   import {
+    applyLayoutToKeys,
     clusterAngle,
     clusterSeparation,
     connectorsString,
@@ -77,6 +78,7 @@
     toggleNumRow,
     toggleOuterCol,
   } from './visualEditorHelpers'
+  import { DEFAULT_LAYOUT, getLayout, isLayoutId, LAYOUT_IDS, type LayoutId } from '$lib/layouts'
   import {
     mdiCodeJson,
     mdiPencil,
@@ -231,6 +233,15 @@
     }
   }
 
+  function updateLayout(ev: Event) {
+    const target = ev.target as HTMLSelectElement
+    if (!isLayoutId(target.value)) return
+    protoConfig.update((proto) => {
+      proto.layout = target.value as LayoutId
+      return applyLayoutToKeys(proto, proto.layout)
+    })
+  }
+
   function updateSwitch(ev: CustomEvent) {
     $protoConfig.partType.type = ev.detail
     const switchType = PART_INFO[$protoConfig.partType.type].keycap
@@ -277,7 +288,11 @@
         proto.clusters.splice(
           cluster == 'fingers' ? 2 : 3,
           0,
-          mirrorCluster(proto.clusters.find((c) => c.side == 'right' && c.name == cluster)!)
+          mirrorCluster(
+            proto.clusters.find((c) => c.side == 'right' && c.name == cluster)!,
+            true,
+            proto.layout
+          )
         )
       }
       return proto
@@ -552,6 +567,17 @@
       labelComponent={SelectProfileLabel}
       minWidth={200}
     />
+  </Field>
+  <Field
+    name="Layout"
+    icon="keycap"
+    help="The keyboard layout printed on the keycaps and used for firmware (ZMK/QMK) keycodes."
+  >
+    <Select value={$protoConfig.layout ?? DEFAULT_LAYOUT} on:change={updateLayout}>
+      {#each LAYOUT_IDS as id}
+        <option value={id}>{getLayout(id).name}</option>
+      {/each}
+    </Select>
   </Field>
   <Field name="Switches" icon="switch">
     <!-- <Select bind:value={$protoConfig.partType.type} on:change={updateSwitch}>

--- a/src/routes/beta/lib/editor/VisualEditor2.svelte
+++ b/src/routes/beta/lib/editor/VisualEditor2.svelte
@@ -60,6 +60,7 @@
     clusterAngle,
     clusterSeparation,
     connectorsString,
+    detectLayout,
     getNKeys,
     getSize,
     getThumbN,
@@ -69,6 +70,7 @@
     isFnKey,
     isNumKey,
     isThumb,
+    missingKeysFor,
     setClusterAngle,
     setClusterSeparation,
     setClusterSize,
@@ -78,7 +80,16 @@
     toggleNumRow,
     toggleOuterCol,
   } from './visualEditorHelpers'
-  import { DEFAULT_LAYOUT, getLayout, isLayoutId, LAYOUT_IDS, type LayoutId } from '$lib/layouts'
+  import { base } from '$app/paths'
+  import {
+    DEFAULT_LAYOUT,
+    isLayoutId,
+    LAYOUT,
+    LAYOUT_IDS,
+    LAYOUT_NAMES,
+    type LayoutId,
+    type NamedLayoutId,
+  } from '$lib/layouts'
   import {
     mdiCodeJson,
     mdiPencil,
@@ -233,13 +244,52 @@
     }
   }
 
+  // Custom-layout dialogs.
+  let customInfoDialog = false
+  let missingKeysDialog: { target: NamedLayoutId; missing: string[] } | null = null
+
   function updateLayout(ev: Event) {
     const target = ev.target as HTMLSelectElement
     if (!isLayoutId(target.value)) return
+    const next = target.value as LayoutId
+    const prev = $protoConfig.layout ?? DEFAULT_LAYOUT
+
+    // Manual switch INTO Custom from a named layout — surface a helper dialog
+    // explaining how to edit individual key legends.
+    if (next === LAYOUT.CUSTOM && prev !== LAYOUT.CUSTOM) {
+      customInfoDialog = true
+    }
+
+    // Switch OUT of Custom into a named layout — refuse if the keyboard
+    // doesn't have enough alpha columns to host the target layout (the user
+    // probably deleted columns earlier).
+    if (prev === LAYOUT.CUSTOM && next !== LAYOUT.CUSTOM) {
+      const missing = missingKeysFor($protoConfig, next as NamedLayoutId)
+      if (missing.length) {
+        missingKeysDialog = { target: next as NamedLayoutId, missing }
+        target.value = LAYOUT.CUSTOM // revert the dropdown to its current state
+        return
+      }
+    }
+
     protoConfig.update((proto) => {
-      proto.layout = target.value as LayoutId
-      return applyLayoutToKeys(proto, proto.layout)
+      proto.layout = next
+      // CUSTOM has no letter mapping — picking it means "leave the keys alone";
+      // applyLayoutToKeys would silently rewrite letters with QWERTY's fallback.
+      if (next === LAYOUT.CUSTOM) return proto
+      return applyLayoutToKeys(proto, next)
     })
+  }
+
+  // Auto-flip to Custom when the user edits an alpha legend (or removes an
+  // alpha column) so the dropdown doesn't keep claiming "Colemak" while the
+  // keymap diverges. Skip when current is already Custom — we don't auto-
+  // promote back to a named layout; the user picks that explicitly.
+  $: if ($protoConfig && ($protoConfig.layout ?? DEFAULT_LAYOUT) !== LAYOUT.CUSTOM) {
+    const detected = detectLayout($protoConfig)
+    if (detected === LAYOUT.CUSTOM) {
+      protoConfig.update((proto) => ({ ...proto, layout: LAYOUT.CUSTOM }))
+    }
   }
 
   function updateSwitch(ev: CustomEvent) {
@@ -575,7 +625,7 @@
   >
     <Select value={$protoConfig.layout ?? DEFAULT_LAYOUT} on:change={updateLayout}>
       {#each LAYOUT_IDS as id}
-        <option value={id}>{getLayout(id).name}</option>
+        <option value={id}>{LAYOUT_NAMES[id]}</option>
       {/each}
     </Select>
   </Field>
@@ -1452,6 +1502,43 @@
     <span slot="title">Set Size Exactly</span>
     <div slot="content">
       <SizeEditView on:size={(e) => setSize(e.detail[0] + 1, e.detail[1], false)} />
+    </div>
+  </Dialog>
+{/if}
+
+{#if customInfoDialog}
+  <Dialog small on:close={() => (customInfoDialog = false)}>
+    <span slot="title">Custom Layout</span>
+    <div slot="content">
+      <p class="mb-2">
+        You've switched to the <b>Custom</b> layout. Cosmos will keep whatever legends you set on each key
+        — it won't overwrite them with QWERTY/Colemak/etc.
+      </p>
+      <p class="mb-2">
+        To change a single key's legend, click the key in the 3D view and edit the <b>Letter</b> field in
+        the right panel. See
+        <a class="text-pink-600 underline" href="{base}/docs/basics/editor/#edit-key" target="_blank"
+          >the docs</a
+        > for a walkthrough.
+      </p>
+    </div>
+  </Dialog>
+{/if}
+
+{#if missingKeysDialog}
+  <Dialog small on:close={() => (missingKeysDialog = null)}>
+    <span slot="title">Missing keys for {LAYOUT_NAMES[missingKeysDialog.target]}</span>
+    <div slot="content">
+      <p class="mb-2">
+        Switching to <b>{LAYOUT_NAMES[missingKeysDialog.target]}</b> needs alpha keys you don't have:
+      </p>
+      <p class="mb-3 font-mono text-center text-lg">
+        {missingKeysDialog.missing.map((l) => `'${l}'`).join('  ')}
+      </p>
+      <p>
+        Add the missing alpha column(s) using the <b>Inner</b> or <b>Outer</b> buttons under
+        <b>Cluster Size</b>, then try the layout again.
+      </p>
     </div>
   </Dialog>
 {/if}

--- a/src/routes/beta/lib/editor/VisualEditor2.svelte
+++ b/src/routes/beta/lib/editor/VisualEditor2.svelte
@@ -570,7 +570,7 @@
   </Field>
   <Field
     name="Layout"
-    icon="keycap"
+    icon="letter"
     help="The keyboard layout printed on the keycaps and used for firmware (ZMK/QMK) keycodes."
   >
     <Select value={$protoConfig.layout ?? DEFAULT_LAYOUT} on:change={updateLayout}>

--- a/src/routes/beta/lib/editor/toCode.ts
+++ b/src/routes/beta/lib/editor/toCode.ts
@@ -40,10 +40,14 @@ function allClustersFlipped(conf: CosmosKeyboard) {
   const newClusters = [...conf.clusters]
   for (const name of ['fingers', 'thumbs'] as ClusterName[]) {
     if (!newClusters.find(c => c.side == 'left' && c.name == name)) {
-      newClusters.push(mirrorCluster({
-        ...newClusters.find(c => c.side == 'right' && c.name == name)!,
-        side: 'left',
-      }))
+      newClusters.push(mirrorCluster(
+        {
+          ...newClusters.find(c => c.side == 'right' && c.name == name)!,
+          side: 'left',
+        },
+        true,
+        conf.layout,
+      ))
     }
   }
   sortClusters(newClusters)

--- a/src/routes/beta/lib/editor/toCode.ts
+++ b/src/routes/beta/lib/editor/toCode.ts
@@ -45,8 +45,7 @@ function allClustersFlipped(conf: CosmosKeyboard) {
           ...newClusters.find(c => c.side == 'right' && c.name == name)!,
           side: 'left',
         },
-        true,
-        conf.layout,
+        conf,
       ))
     }
   }

--- a/src/routes/beta/lib/editor/visualEditorHelpers.ts
+++ b/src/routes/beta/lib/editor/visualEditorHelpers.ts
@@ -1,4 +1,5 @@
 import { PART_INFO } from '$lib/geometry/socketsParts'
+import { flipLetter, type LayoutId, rightSideLetter } from '$lib/layouts'
 import { approximateCosmosThumbOrigin, cosmosFingers, type Cuttleform, decodeTuple, encodeTuple, type FullCuttleform, newGeometry } from '$lib/worker/config'
 import {
   type ConnectorMaybeCustom,
@@ -42,7 +43,7 @@ export function setClusterSize(keyboard: CosmosKeyboard, side: 'left' | 'right',
   if (side == 'left') newThumb.x *= -1
   const newPosition = originalPosition.add(originalThumb).sub(newThumb)
   const newTup = encodeTuple(newPosition.toArray().map((x) => Math.round(10 * x)))
-  fingers.clusters = cosmosFingers(rows, cols, side, addExtraRow)
+  fingers.clusters = cosmosFingers(rows, cols, side, addExtraRow, keyboard.layout)
   fingers.position = newTup
 
   return keyboard
@@ -196,7 +197,7 @@ export function setThumbCluster(c: CosmosKeyboard, type: Thumb, side: 'left' | '
   }
   // Erase all key labels
   cluster.clusters.forEach(c => c.keys.forEach(k => k.profile.letter = undefined))
-  if (side == 'left') cluster = mirrorCluster(cluster)
+  if (side == 'left') cluster = mirrorCluster(cluster, true, c.layout)
 
   const thumb = c.clusters.find((c) => c.name == 'thumbs' && c.side == side)
   if (!thumb) return c
@@ -478,4 +479,36 @@ export function toggleInnerCol(kbd: CosmosKeyboard) {
     // Add the column
     return addCol(kbd, -1)
   }
+}
+
+/**
+ * Update alpha-row letters across all finger clusters to match `layoutId`.
+ * Non-alpha rows (numbers, F-row, outer punctuation) are layout-independent and
+ * are left untouched. Alpha columns are identified by `alphaColumns()`, so user
+ * geometry (extra inner/outer columns, splay) is preserved.
+ */
+export function applyLayoutToKeys(kbd: CosmosKeyboard, layoutId: LayoutId): CosmosKeyboard {
+  return mapClusters(kbd, cluster => {
+    if (cluster.name !== 'fingers') return cluster
+    const alphas = alphaColumns(kbd, cluster)
+    const N = alphas.length
+    if (N === 0) return cluster
+    return mapClusters(cluster, (col, colIdx) => {
+      const alphaIdx = alphas.indexOf(colIdx)
+      if (alphaIdx < 0) return col
+      const letterCol = cluster.side === 'right' ? alphaIdx : (N - 1 - alphaIdx)
+      return {
+        ...col,
+        keys: col.keys.map(k => {
+          const row = k.profile.row
+          if (row !== 2 && row !== 3 && row !== 4) return k
+          if (!k.profile.letter) return k
+          let newLetter = rightSideLetter(row, letterCol, layoutId)
+          if (cluster.side === 'left') newLetter = flipLetter(newLetter, layoutId)
+          if (!newLetter) return k
+          return { ...k, profile: { ...k.profile, letter: newLetter } }
+        }),
+      }
+    })
+  })
 }

--- a/src/routes/beta/lib/editor/visualEditorHelpers.ts
+++ b/src/routes/beta/lib/editor/visualEditorHelpers.ts
@@ -1,11 +1,13 @@
 import { PART_INFO } from '$lib/geometry/socketsParts'
-import { DEFAULT_LAYOUT, flipLetter, getLayout, isAlphaLetter, LAYOUT, type LayoutId, NAMED_LAYOUT_IDS, type NamedLayoutId, rightSideLetter } from '$lib/layouts'
+import { DEFAULT_LAYOUT, flipLetter, isAlphaLetter, LAYOUT, type LayoutId, rightSideLetter } from '$lib/layouts'
 import { approximateCosmosThumbOrigin, cosmosFingers, type Cuttleform, decodeTuple, encodeTuple, type FullCuttleform, newGeometry } from '$lib/worker/config'
 import {
+  alphaColumns,
   type ConnectorMaybeCustom,
   type CosmosCluster,
   type CosmosKey,
   type CosmosKeyboard,
+  detectLayout,
   fromCosmosConfig,
   indexOfKey,
   mirrorCluster,
@@ -13,7 +15,7 @@ import {
   sideFromCosmosConfig,
   toCosmosConfig,
 } from '$lib/worker/config.cosmos'
-import { decodeCosmosCluster, LETTERS } from '$lib/worker/config.serialize'
+import { decodeCosmosCluster } from '$lib/worker/config.serialize'
 import { estimatedBB } from '$lib/worker/geometry'
 import { Vector } from '$lib/worker/modeling/transformation'
 import { mapObj, objKeys, sum } from '$lib/worker/util'
@@ -43,7 +45,13 @@ export function setClusterSize(keyboard: CosmosKeyboard, side: 'left' | 'right',
   if (side == 'left') newThumb.x *= -1
   const newPosition = originalPosition.add(originalThumb).sub(newThumb)
   const newTup = encodeTuple(newPosition.toArray().map((x) => Math.round(10 * x)))
-  fingers.clusters = cosmosFingers(rows, cols, side, addExtraRow, keyboard.layout)
+  // Detect the kbd's current layout BEFORE we replace the cluster — the new
+  // alpha keys get seeded with that layout's letters. CUSTOM has no rightRows,
+  // so fall back to QWERTY for the seeding (the user's existing letters
+  // outside the alpha block are preserved by the unchanged outer columns).
+  const detected = detectLayout(keyboard)
+  const seedLayout = detected === LAYOUT.CUSTOM ? DEFAULT_LAYOUT : detected
+  fingers.clusters = cosmosFingers(rows, cols, side, addExtraRow, seedLayout)
   fingers.position = newTup
 
   return keyboard
@@ -197,7 +205,7 @@ export function setThumbCluster(c: CosmosKeyboard, type: Thumb, side: 'left' | '
   }
   // Erase all key labels
   cluster.clusters.forEach(c => c.keys.forEach(k => k.profile.letter = undefined))
-  if (side == 'left') cluster = mirrorCluster(cluster, true, c.layout)
+  if (side == 'left') cluster = mirrorCluster(cluster, c)
 
   const thumb = c.clusters.find((c) => c.name == 'thumbs' && c.side == side)
   if (!thumb) return c
@@ -210,7 +218,7 @@ export function setThumbCluster(c: CosmosKeyboard, type: Thumb, side: 'left' | '
 }
 
 const decodedClusters = mapObj(THUMB_CONFIG, ({ b64 }) => decodeCosmosCluster(Cluster.fromBinary(Uint8Array.from(atob(b64), c => c.charCodeAt(0)))))
-const mirroredDecodedClusters = mapObj(decodedClusters, c => mirrorCluster(c))
+const mirroredDecodedClusters = mapObj(decodedClusters, c => mirrorCluster(c, undefined))
 
 export function getThumbN(c: CosmosKeyboard, side: 'left' | 'right') {
   const thumb = c.clusters.find((c) => c.name == 'thumbs' && c.side == side)
@@ -321,23 +329,6 @@ export function filterKeys(kbd: CosmosKeyboard, predicate: (k: CosmosKey, col: C
 export function mapKeys<T>(kbd: CosmosKeyboard, predicate: (k: CosmosKey, col: CosmosCluster, cl: CosmosCluster, index: number) => T): T[] {
   let i = 0
   return kbd.clusters.flatMap(cluster => cluster.clusters.flatMap(col => col.keys.map(k => predicate(k, col, cluster, i++))))
-}
-
-/** Find the indices of the five alpha/letter columns.
- * These are determined by finding the 5 columns with the largest number of letters.
- * They are sorted by column position from smallest to largest
- */
-function alphaColumns(kbd: CosmosKeyboard, cluster: CosmosCluster) {
-  const columns = cluster.clusters.map((col, index) => ({
-    index,
-    column: col.column ?? -1000,
-    nLetters: col.keys
-      .filter(k => PART_INFO[k.partType.type || col.partType.type || kbd.partType.type!].keycap && LETTERS.includes(k.profile.letter!))
-      .length,
-  })).filter(c => c.nLetters > 0)
-  columns.sort((a, b) => b.nLetters - a.nLetters)
-  const topColumns = columns.slice(0, 5)
-  return topColumns.sort((a, b) => a.column - b.column).map(c => c.index)
 }
 
 export function addRow(kbd: CosmosKeyboard, fn: (side: 'left' | 'right', alphas: number[], row: number, column: number) => string | null) {
@@ -515,101 +506,4 @@ export function applyLayoutToKeys(kbd: CosmosKeyboard, layoutId: LayoutId): Cosm
       }
     })
   })
-}
-
-/**
- * Canonical width of the alpha block (Q-W-E-R-T on row 2, A-S-D-F-G on row 3,
- * Z-X-C-V-B on row 4 for QWERTY). All registered layouts share this 5-col
- * core; the 6th column on row 3 (`'` in QWERTY/Colemak/Workman, `-` in Dvorak)
- * is an optional outer-pinky punctuation that some keyboards include.
- *
- * detectLayout matches against the first STANDARD_ALPHA_COLS positions and
- * ignores extras in either direction. missingKeysFor uses the same width to
- * compute what the user needs to add to host a named layout.
- */
-const STANDARD_ALPHA_COLS = 5
-
-/**
- * Inspect `kbd`'s right-finger alpha block and return the named layout it
- * matches one-for-one, or `LAYOUT.CUSTOM` if no named layout fits.
- *
- * Match rules:
- *   - The keyboard must have at least STANDARD_ALPHA_COLS alpha columns —
- *     fewer can't host any layout's full alpha block, so the answer is CUSTOM.
- *   - Positions [0, STANDARD_ALPHA_COLS) on rows 2/3/4 must agree with the
- *     candidate layout's right-side letters (left-side keyboards compare
- *     against the layout's flipMap-mirrored letters).
- *   - Extra alpha columns beyond the canonical block are ignored — adding
- *     keys "outside the layout's range" shouldn't flip the dropdown.
- *
- * Used by:
- *   - the expert→basic mode transition (so the layout dropdown reflects the
- *     keymap the user actually has, instead of always reverting to QWERTY)
- *   - the "did the user start customizing?" auto-flip to CUSTOM after a
- *     legend edit or column delete
- */
-export function detectLayout(kbd: CosmosKeyboard): LayoutId {
-  const cluster = kbd.clusters.find(c => c.name === 'fingers' && c.side === 'right')
-    ?? kbd.clusters.find(c => c.name === 'fingers')
-  if (!cluster) return DEFAULT_LAYOUT
-  const alphas = alphaColumns(kbd, cluster)
-  if (alphas.length < STANDARD_ALPHA_COLS) return LAYOUT.CUSTOM
-  const isLeft = cluster.side === 'left'
-
-  const observed: Record<2 | 3 | 4, (string | undefined)[]> = { 2: [], 3: [], 4: [] }
-  for (let i = 0; i < alphas.length; i++) {
-    const col = cluster.clusters[alphas[i]]
-    const letterCol = isLeft ? alphas.length - 1 - i : i
-    for (const row of [2, 3, 4] as const) {
-      const key = col.keys.find(k => k.profile.row === row && isAlphaLetter(k.profile.letter))
-      observed[row][letterCol] = key?.profile.letter
-    }
-  }
-
-  for (const id of NAMED_LAYOUT_IDS) {
-    const layout = getLayout(id)
-    if (
-      rowMatches(observed[2], layout.rightRows[2], isLeft, id)
-      && rowMatches(observed[3], layout.rightRows[3], isLeft, id)
-      && rowMatches(observed[4], layout.rightRows[4], isLeft, id)
-    ) {
-      return id
-    }
-  }
-  return LAYOUT.CUSTOM
-}
-
-function rowMatches(observed: (string | undefined)[], layoutRow: string, isLeft: boolean, layoutId: NamedLayoutId): boolean {
-  const upper = Math.min(STANDARD_ALPHA_COLS, layoutRow.length)
-  for (let col = 0; col < upper; col++) {
-    const expectedRight = layoutRow.charAt(col) || undefined
-    if (!expectedRight) continue
-    const expected = isLeft ? flipLetter(expectedRight, layoutId) : expectedRight
-    const observedLetter = observed[col]
-    if (!observedLetter || observedLetter !== expected) return false
-  }
-  return true
-}
-
-/**
- * Letters the named layout requires that the keyboard's right-finger alpha
- * block can't currently host (because the user removed columns down past the
- * canonical 5-col block). Empty when the keyboard has at least
- * STANDARD_ALPHA_COLS alpha columns.
- */
-export function missingKeysFor(kbd: CosmosKeyboard, target: NamedLayoutId): string[] {
-  const cluster = kbd.clusters.find(c => c.name === 'fingers' && c.side === 'right')
-    ?? kbd.clusters.find(c => c.name === 'fingers')
-  if (!cluster) return []
-  const have = alphaColumns(kbd, cluster).length
-  if (have >= STANDARD_ALPHA_COLS) return []
-  const layout = getLayout(target)
-  const missing: string[] = []
-  for (let col = have; col < STANDARD_ALPHA_COLS; col++) {
-    for (const row of [2, 3, 4] as const) {
-      const letter = layout.rightRows[row].charAt(col)
-      if (letter) missing.push(letter)
-    }
-  }
-  return missing
 }

--- a/src/routes/beta/lib/editor/visualEditorHelpers.ts
+++ b/src/routes/beta/lib/editor/visualEditorHelpers.ts
@@ -1,5 +1,5 @@
 import { PART_INFO } from '$lib/geometry/socketsParts'
-import { flipLetter, type LayoutId, rightSideLetter } from '$lib/layouts'
+import { flipLetter, isAlphaLetter, type LayoutId, rightSideLetter } from '$lib/layouts'
 import { approximateCosmosThumbOrigin, cosmosFingers, type Cuttleform, decodeTuple, encodeTuple, type FullCuttleform, newGeometry } from '$lib/worker/config'
 import {
   type ConnectorMaybeCustom,
@@ -502,7 +502,11 @@ export function applyLayoutToKeys(kbd: CosmosKeyboard, layoutId: LayoutId): Cosm
         keys: col.keys.map(k => {
           const row = k.profile.row
           if (row !== 2 && row !== 3 && row !== 4) return k
-          if (!k.profile.letter) return k
+          // keycapInfo() collapses row 5 → 4 for MT3 keycap-profile reasons,
+          // so a row check alone wrongly catches row-5 outer punctuation
+          // ([, ], etc). Gate on whether the letter is one a layout actually
+          // manages.
+          if (!isAlphaLetter(k.profile.letter)) return k
           let newLetter = rightSideLetter(row, letterCol, layoutId)
           if (cluster.side === 'left') newLetter = flipLetter(newLetter, layoutId)
           if (!newLetter) return k

--- a/src/routes/beta/lib/editor/visualEditorHelpers.ts
+++ b/src/routes/beta/lib/editor/visualEditorHelpers.ts
@@ -1,5 +1,5 @@
 import { PART_INFO } from '$lib/geometry/socketsParts'
-import { flipLetter, isAlphaLetter, type LayoutId, rightSideLetter } from '$lib/layouts'
+import { DEFAULT_LAYOUT, flipLetter, getLayout, isAlphaLetter, LAYOUT, type LayoutId, NAMED_LAYOUT_IDS, type NamedLayoutId, rightSideLetter } from '$lib/layouts'
 import { approximateCosmosThumbOrigin, cosmosFingers, type Cuttleform, decodeTuple, encodeTuple, type FullCuttleform, newGeometry } from '$lib/worker/config'
 import {
   type ConnectorMaybeCustom,
@@ -515,4 +515,101 @@ export function applyLayoutToKeys(kbd: CosmosKeyboard, layoutId: LayoutId): Cosm
       }
     })
   })
+}
+
+/**
+ * Canonical width of the alpha block (Q-W-E-R-T on row 2, A-S-D-F-G on row 3,
+ * Z-X-C-V-B on row 4 for QWERTY). All registered layouts share this 5-col
+ * core; the 6th column on row 3 (`'` in QWERTY/Colemak/Workman, `-` in Dvorak)
+ * is an optional outer-pinky punctuation that some keyboards include.
+ *
+ * detectLayout matches against the first STANDARD_ALPHA_COLS positions and
+ * ignores extras in either direction. missingKeysFor uses the same width to
+ * compute what the user needs to add to host a named layout.
+ */
+const STANDARD_ALPHA_COLS = 5
+
+/**
+ * Inspect `kbd`'s right-finger alpha block and return the named layout it
+ * matches one-for-one, or `LAYOUT.CUSTOM` if no named layout fits.
+ *
+ * Match rules:
+ *   - The keyboard must have at least STANDARD_ALPHA_COLS alpha columns —
+ *     fewer can't host any layout's full alpha block, so the answer is CUSTOM.
+ *   - Positions [0, STANDARD_ALPHA_COLS) on rows 2/3/4 must agree with the
+ *     candidate layout's right-side letters (left-side keyboards compare
+ *     against the layout's flipMap-mirrored letters).
+ *   - Extra alpha columns beyond the canonical block are ignored — adding
+ *     keys "outside the layout's range" shouldn't flip the dropdown.
+ *
+ * Used by:
+ *   - the expert→basic mode transition (so the layout dropdown reflects the
+ *     keymap the user actually has, instead of always reverting to QWERTY)
+ *   - the "did the user start customizing?" auto-flip to CUSTOM after a
+ *     legend edit or column delete
+ */
+export function detectLayout(kbd: CosmosKeyboard): LayoutId {
+  const cluster = kbd.clusters.find(c => c.name === 'fingers' && c.side === 'right')
+    ?? kbd.clusters.find(c => c.name === 'fingers')
+  if (!cluster) return DEFAULT_LAYOUT
+  const alphas = alphaColumns(kbd, cluster)
+  if (alphas.length < STANDARD_ALPHA_COLS) return LAYOUT.CUSTOM
+  const isLeft = cluster.side === 'left'
+
+  const observed: Record<2 | 3 | 4, (string | undefined)[]> = { 2: [], 3: [], 4: [] }
+  for (let i = 0; i < alphas.length; i++) {
+    const col = cluster.clusters[alphas[i]]
+    const letterCol = isLeft ? alphas.length - 1 - i : i
+    for (const row of [2, 3, 4] as const) {
+      const key = col.keys.find(k => k.profile.row === row && isAlphaLetter(k.profile.letter))
+      observed[row][letterCol] = key?.profile.letter
+    }
+  }
+
+  for (const id of NAMED_LAYOUT_IDS) {
+    const layout = getLayout(id)
+    if (
+      rowMatches(observed[2], layout.rightRows[2], isLeft, id)
+      && rowMatches(observed[3], layout.rightRows[3], isLeft, id)
+      && rowMatches(observed[4], layout.rightRows[4], isLeft, id)
+    ) {
+      return id
+    }
+  }
+  return LAYOUT.CUSTOM
+}
+
+function rowMatches(observed: (string | undefined)[], layoutRow: string, isLeft: boolean, layoutId: NamedLayoutId): boolean {
+  const upper = Math.min(STANDARD_ALPHA_COLS, layoutRow.length)
+  for (let col = 0; col < upper; col++) {
+    const expectedRight = layoutRow.charAt(col) || undefined
+    if (!expectedRight) continue
+    const expected = isLeft ? flipLetter(expectedRight, layoutId) : expectedRight
+    const observedLetter = observed[col]
+    if (!observedLetter || observedLetter !== expected) return false
+  }
+  return true
+}
+
+/**
+ * Letters the named layout requires that the keyboard's right-finger alpha
+ * block can't currently host (because the user removed columns down past the
+ * canonical 5-col block). Empty when the keyboard has at least
+ * STANDARD_ALPHA_COLS alpha columns.
+ */
+export function missingKeysFor(kbd: CosmosKeyboard, target: NamedLayoutId): string[] {
+  const cluster = kbd.clusters.find(c => c.name === 'fingers' && c.side === 'right')
+    ?? kbd.clusters.find(c => c.name === 'fingers')
+  if (!cluster) return []
+  const have = alphaColumns(kbd, cluster).length
+  if (have >= STANDARD_ALPHA_COLS) return []
+  const layout = getLayout(target)
+  const missing: string[] = []
+  for (let col = have; col < STANDARD_ALPHA_COLS; col++) {
+    for (const row of [2, 3, 4] as const) {
+      const letter = layout.rightRows[row].charAt(col)
+      if (letter) missing.push(letter)
+    }
+  }
+  return missing
 }

--- a/src/routes/beta/lib/firmware/qmk.ts
+++ b/src/routes/beta/lib/firmware/qmk.ts
@@ -359,7 +359,7 @@ const EXTRAKEY_REQUIRED = new Set([
 ])
 
 /** Return the QMK keycode for a letter */
-function keycode(code: string | undefined) {
+export function keycode(code: string | undefined) {
   const c = code?.toLowerCase()
 
   if (!c || !code) return 'KC_SPACE'

--- a/src/routes/beta/lib/firmware/zmk.ts
+++ b/src/routes/beta/lib/firmware/zmk.ts
@@ -426,8 +426,9 @@ config SHIELD_${options.folderName}_RIGHT
 
 function generateConf(config: FullGeometry, options: ZMKOptions, side: keyof FullGeometry) {
   const wired = options.microcontroller === Microcontroller.LemonWired
-  const usbSplit = wired && options.splitTransport !== SplitTransport.Uart
-  const isCentral = side === 'unibody' || side === options.centralSide
+  const split = side !== 'unibody'
+  const usbSplit = wired && split && options.splitTransport !== SplitTransport.Uart
+  const isCentral = split && side === options.centralSide
   // Phase 1: the wired path doesn't yet ship a working WS2812 driver
   // (RP2040 needs a PIO-based ws2812 binding the upstream Zephyr 3.5 doesn't
   // have). Force underglow off so the build completes; revisit once the wired
@@ -435,6 +436,11 @@ function generateConf(config: FullGeometry, options: ZMKOptions, side: keyof Ful
   const underglow = options.underGlowAtStart && !wired
   const hasPointing = Object.values(options.peripherals).some(p => p.pmw3610 || p.cirque)
   const hasEncoder = Object.values(options.peripherals).some(p => p.encoder)
+  // USB device strings. Peripheral re-uses the central PID — the host only
+  // ever sees the central, so a unique PID on the peripheral has no observer.
+  // The 16-char limit on ZMK_KEYBOARD_NAME is BLE-specific; USB strings have
+  // no such cap.
+  const productName = options.keyboardName + (usbSplit && !isCentral ? ' (peripheral)' : '')
   return [
     'CONFIG_SPI=y',
     '',
@@ -456,24 +462,47 @@ function generateConf(config: FullGeometry, options: ZMKOptions, side: keyof Ful
         'CONFIG_PINCTRL=y',
         'CONFIG_GPIO=y',
         '',
+        '# Zephyr 3.5 RP2040 flash driver is broken in this fork — non-persistent',
+        '# settings until that lands. The board defconfig sets these to y; we override.',
+        'CONFIG_FLASH=n',
+        'CONFIG_NVS=n',
+        'CONFIG_SETTINGS=n',
+        '',
         ...(usbSplit
           ? [
             '# Pico-PIO-USB split transport: legacy USB device stack on the',
             '# native USB-C carries HID (central) / split bulk endpoints (peripheral);',
             '# the central also runs Pico-PIO-USB as a UHC on the Link port.',
             'CONFIG_USB_DEVICE_STACK=y',
+            `CONFIG_USB_DEVICE_PRODUCT="${productName}"`,
+            `CONFIG_USB_DEVICE_VID=${options.vid}`,
+            `CONFIG_USB_DEVICE_PID=${options.pid}`,
             'CONFIG_USB_CDC_ACM=y',
             'CONFIG_SERIAL=y',
             'CONFIG_UART_INTERRUPT_DRIVEN=y',
             'CONFIG_UART_LINE_CTRL=y',
             'CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=' + (isCentral ? 'y' : 'n'),
             ...(isCentral ? ['CONFIG_ZMK_USB=y'] : []),
+            ...(isCentral && options.enableConsole
+              ? [
+                '',
+                '# CDC ACM console on the central native USB-C (alongside HID).',
+                'CONFIG_CONSOLE=y',
+                'CONFIG_UART_CONSOLE=y',
+                'CONFIG_LOG=y',
+                'CONFIG_LOG_PRINTK=y',
+                'CONFIG_LOG_BACKEND_UART=y',
+                'CONFIG_LOG_DEFAULT_LEVEL=2',
+              ]
+              : []),
           ]
-          : [
+          : split
+          ? [
             '# Wired-split UART transport on GP0/GP1',
             'CONFIG_ZMK_SPLIT_WIRED=y',
-          ]),
-        'CONFIG_ZMK_SPLIT=y',
+          ]
+          : []),
+        ...(split ? ['CONFIG_ZMK_SPLIT=y'] : []),
       ]
       : []),
     '',

--- a/src/routes/beta/lib/firmware/zmk.ts
+++ b/src/routes/beta/lib/firmware/zmk.ts
@@ -155,10 +155,86 @@ function generateKeycodes(config: FullGeometry, matrix: Matrix, options: ZMKOpti
   return keycodes
 }
 
-/** Returns the board name used for the given config */
+/** Returns the Zephyr board name used for the given microcontroller selection.
+ *  The Lemon Wireless board ships in `rianadon/zmk`; the Lemon Wired board
+ *  ships in the Phase-1 fork branch wired up by generateWestYaml. */
 function boardName(options: ZMKOptions) {
+  if (options.microcontroller === 'lemon-wired') {
+    return options.wiredVersion === 'v0.5' ? 'cosmos_lemon_wired_v5' : 'cosmos_lemon_wired'
+  }
   if (options.wirelessVersion == 'v0.4') return 'cosmos_lemon_wireless_v4'
   return 'cosmos_lemon_wireless'
+}
+
+type GpioPin = { ctrl: '&gpio0' | '&gpio1'; pin: number }
+
+interface MCUProfile {
+  /** Row GPIOs for the matrix scan. */
+  rows: GpioPin[]
+  /** Column GPIOs when columns are driven directly (no shifter). */
+  cols?: GpioPin[]
+  /** SPI-driven 595 shifter for column expansion. When set, `cols` is ignored
+   *  and columns reference the shifter outputs. */
+  shifter?: { spiBus: string; csPin: GpioPin }
+  /** Encoder A/B GPIOs (one encoder per side). */
+  encoderA: GpioPin
+  encoderB: GpioPin
+  /** When set, hold an LED-power enable pin in its OFF state at boot using a
+   *  gpio-hog. Used when the user opts not to start with underglow on. */
+  extPowerHog?: {
+    pin: GpioPin
+    activeMode: 'GPIO_ACTIVE_HIGH' | 'GPIO_ACTIVE_LOW'
+    offLevel: 'high' | 'low'
+  }
+  /** VIK_SPI_REG_START: number of devices already on the VIK SPI bus before
+   *  VIK peripherals (e.g. the Wireless shifter occupies slot 0). */
+  vikSpiRegStart: number
+  /** VIK_SPI_CS_PREFIX expression. Omitted when nothing precedes VIK on the bus. */
+  vikSpiCsPrefix?: string
+}
+
+function mcuProfile(options: ZMKOptions): MCUProfile {
+  if (options.microcontroller === 'lemon-wired') {
+    const v05 = options.wiredVersion === 'v0.5'
+    return {
+      rows: [3, 4, 5, 6, 7, 8, 9].map((pin): GpioPin => ({ ctrl: '&gpio0', pin })),
+      cols: [25, 24, 23, 22, 21, 20, 10].map((pin): GpioPin => ({ ctrl: '&gpio0', pin })),
+      encoderA: { ctrl: '&gpio0', pin: 28 },
+      encoderB: { ctrl: '&gpio0', pin: 29 },
+      extPowerHog: options.underGlowAtStart ? undefined : {
+        pin: { ctrl: '&gpio0', pin: 11 },
+        activeMode: v05 ? 'GPIO_ACTIVE_HIGH' : 'GPIO_ACTIVE_LOW',
+        offLevel: v05 ? 'low' : 'high',
+      },
+      vikSpiRegStart: 0,
+    }
+  }
+  // lemon-wireless: existing behavior (matched 1:1 with the prior hard-coded DTSI).
+  return {
+    rows: [
+      { ctrl: '&gpio0', pin: 20 },
+      { ctrl: '&gpio0', pin: 22 },
+      { ctrl: '&gpio0', pin: 24 },
+      { ctrl: '&gpio0', pin: 9 },
+      { ctrl: '&gpio0', pin: 10 },
+      { ctrl: '&gpio1', pin: 13 },
+      { ctrl: '&gpio1', pin: 15 },
+    ],
+    shifter: { spiBus: '&spi1', csPin: { ctrl: '&gpio0', pin: 4 } },
+    encoderA: { ctrl: '&gpio0', pin: 29 },
+    encoderB: { ctrl: '&gpio0', pin: 31 },
+    extPowerHog: options.underGlowAtStart ? undefined : {
+      pin: { ctrl: '&gpio0', pin: 2 },
+      activeMode: 'GPIO_ACTIVE_LOW',
+      offLevel: 'high',
+    },
+    vikSpiRegStart: 1,
+    vikSpiCsPrefix: '<&gpio0 4 GPIO_ACTIVE_LOW>',
+  }
+}
+
+function gpioRef(p: GpioPin, flags?: string) {
+  return flags ? `<${p.ctrl} ${p.pin} ${flags}>` : `<${p.ctrl} ${p.pin}>`
 }
 
 function generateEncoderMap(encodersPerSide: Record<keyof FullGeometry, number>) {
@@ -271,15 +347,21 @@ function generateDepsYaml(): string {
   })
 }
 
-function generateWestYaml(): string {
+function generateWestYaml(options: ZMKOptions): string {
+  // The Lemon Wired board lives on the Phase-1 branch of the Olson3R fork
+  // until that work merges upstream. Wireless continues to track rianadon/zmk.
+  const wired = options.microcontroller === 'lemon-wired'
   return yamlFile({
     manifest: {
       remotes: [
         { name: 'zmkfirmware', 'url-base': 'https://github.com/zmkfirmware' },
         { name: 'rianadon', 'url-base': 'https://github.com/rianadon' },
+        ...(wired ? [{ name: 'Olson3R', 'url-base': 'https://github.com/Olson3R' }] : []),
       ],
       projects: [
-        { name: 'zmk', remote: 'rianadon', revision: 'main', import: 'app/west.yml' },
+        wired
+          ? { name: 'zmk', 'repo-path': 'rainadon-zmk', remote: 'Olson3R', revision: 'lemon-wired-zmk-phase1', import: 'app/west.yml' }
+          : { name: 'zmk', remote: 'rianadon', revision: 'main', import: 'app/west.yml' },
       ],
       self: { path: 'config', import: 'deps.yml' },
     },
@@ -320,13 +402,21 @@ config SHIELD_${options.folderName}_RIGHT
 }
 
 function generateConf(config: FullGeometry, options: ZMKOptions) {
+  const wired = options.microcontroller === 'lemon-wired'
+  // Phase 1: the wired path doesn't yet ship a working WS2812 driver
+  // (RP2040 needs a PIO-based ws2812 binding the upstream Zephyr 3.5 doesn't
+  // have). Force underglow off so the build completes; revisit once the wired
+  // board overlay grows a working LED strip definition.
+  const underglow = options.underGlowAtStart && !wired
+  const hasPointing = Object.values(options.peripherals).some(p => p.pmw3610 || p.cirque)
+  const hasEncoder = Object.values(options.peripherals).some(p => p.encoder)
   return [
     'CONFIG_SPI=y',
     '',
     '# RGB underglow configuration',
-    'CONFIG_ZMK_RGB_UNDERGLOW=' + (options.underGlowAtStart ? 'y' : 'n'),
-    'CONFIG_WS2812_STRIP=' + (options.underGlowAtStart ? 'y' : 'n'),
-    ...(options.underGlowAtStart
+    'CONFIG_ZMK_RGB_UNDERGLOW=' + (underglow ? 'y' : 'n'),
+    'CONFIG_WS2812_STRIP=' + (underglow ? 'y' : 'n'),
+    ...(underglow
       ? [
         'CONFIG_ZMK_RGB_UNDERGLOW_BRT_START=50',
         'CONFIG_ZMK_RGB_UNDERGLOW_EFF_START=3',
@@ -334,13 +424,25 @@ function generateConf(config: FullGeometry, options: ZMKOptions) {
       : [
         'CONFIG_ZMK_EXT_POWER=n',
       ]),
+    ...(wired
+      ? [
+        '',
+        '# RP2040 essentials',
+        'CONFIG_PINCTRL=y',
+        'CONFIG_GPIO=y',
+        '',
+        '# Wired-split UART transport on GP0/GP1',
+        'CONFIG_ZMK_SPLIT=y',
+        'CONFIG_ZMK_SPLIT_WIRED=y',
+      ]
+      : []),
     '',
     '# zmk mouse emulation for trackball/trackpad',
-    'CONFIG_ZMK_POINTING=' + (Object.values(options.peripherals).some(p => p.pmw3610 || p.cirque) ? 'y' : 'n'),
+    'CONFIG_ZMK_POINTING=' + (hasPointing ? 'y' : 'n'),
     '',
     '# encoder support',
-    'CONFIG_EC11=' + (Object.values(options.peripherals).some(p => p.encoder) ? 'y' : 'n'),
-    'CONFIG_EC11_TRIGGER_GLOBAL_THREAD=' + (Object.values(options.peripherals).some(p => p.encoder) ? 'y' : 'n'),
+    'CONFIG_EC11=' + (hasEncoder ? 'y' : 'n'),
+    'CONFIG_EC11_TRIGGER_GLOBAL_THREAD=' + (hasEncoder ? 'y' : 'n'),
   ].join('\n') + '\n'
 }
 
@@ -349,30 +451,64 @@ function generateDTSI(config: FullGeometry, matrix: Matrix, options: ZMKOptions)
   const pullMode = options.diodeDirection == 'COL2ROW' ? 'GPIO_PULL_DOWN' : 'GPIO_PULL_UP'
   const encoders = mapObjNotNull(config, (g) => encoderKeys(g.c))
   const encodersWithLength = filterObj(encoders, (k, v) => v.length > 0)
+  const profile = mcuProfile(options)
+
+  const rowGpios = profile.rows.map(p => gpioRef(p, `(${activeMode} | ${pullMode})`))
+  const colGpios = profile.shifter
+    ? Array.from({ length: 7 }, (_, i) => `<&shifter ${i} ${activeMode}>`)
+    : (profile.cols ?? []).map(p => gpioRef(p, activeMode))
+
+  const shifterBlock: Record<string, unknown> = profile.shifter
+    ? {
+      [profile.shifter.spiBus]: {
+        status: 'okay',
+        csGpios: ['VIK_SPI_CS_PREFIX'],
+        'shifter: 595@0': {
+          compatible: 'zmk,gpio-595',
+          status: 'okay',
+          gpioController: true,
+          spiMaxFrequency: 200000,
+          reg: 0,
+          ngpios: 8,
+          '#gpio-cells': 2,
+        },
+      },
+    }
+    : {}
+
+  const vikSpiDefines: Record<string, unknown> = {
+    [raw()]: `// Tell VIK how many devices already sit on the VIK SPI bus before VIK peripherals.`,
+    [raw()]: `// Increase this number if you add another SPI device.`,
+    [raw()]: `#define VIK_SPI_REG_START ${profile.vikSpiRegStart}`,
+    ...(profile.vikSpiCsPrefix
+      ? {
+        [raw()]: '// Pulled out to an external variable so VIK can find the SPI bus.',
+        [raw()]: `#define VIK_SPI_CS_PREFIX ${profile.vikSpiCsPrefix}`,
+      }
+      : {}),
+  }
+
+  const extPowerBlock: Record<string, unknown> = profile.extPowerHog
+    ? {
+      [raw()]: '// Hack to force-drive the LED power pin to its OFF level, ensuring LEDs stay off at boot.',
+      [raw()]: '// Ext power is also disabled in the conf file.',
+      [profile.extPowerHog.pin.ctrl]: {
+        'ext_power_hog: ext_power_hog': {
+          'gpio-hog': true,
+          'gpios': [`<${profile.extPowerHog.pin.pin} ${profile.extPowerHog.activeMode}>`],
+          [`output-${profile.extPowerHog.offLevel}`]: true,
+        },
+      },
+    }
+    : {}
 
   return dtsFile({
     [raw()]: '#include <behaviors.dtsi>',
     [raw()]: '#include <dt-bindings/zmk/matrix_transform.h>',
     [raw()]: '#include <dt-bindings/zmk/keys.h>',
     [raw()]: `#include "${options.folderName}-layouts.dtsi"`,
-    [raw()]: '// Tell VIK that there is 1 other device on the SPI bus.',
-    [raw()]: '// You will need to increase this number if you add another SPI device.',
-    [raw()]: '#define VIK_SPI_REG_START 1',
-    [raw()]: '// Pulled out to an external variable so VIK can find the SPI bus.',
-    [raw()]: '#define VIK_SPI_CS_PREFIX <&gpio0 4 GPIO_ACTIVE_LOW>',
-    '&spi1': {
-      status: 'okay',
-      csGpios: ['VIK_SPI_CS_PREFIX'],
-      'shifter: 595@0': {
-        compatible: 'zmk,gpio-595',
-        status: 'okay',
-        gpioController: true,
-        spiMaxFrequency: 200000,
-        reg: 0,
-        ngpios: 8,
-        '#gpio-cells': 2,
-      },
-    },
+    ...vikSpiDefines,
+    ...shifterBlock,
     '/': {
       'chosen': {
         'zmk,kscan': '&kscan0',
@@ -388,30 +524,14 @@ function generateDTSI(config: FullGeometry, matrix: Matrix, options: ZMKOptions)
       'kscan0: kscan_0': {
         compatible: 'zmk,kscan-gpio-matrix',
         diodeDirection: 'col2row',
-        rowGpios: [
-          `<&gpio0 20 (${activeMode} | ${pullMode})>`,
-          `<&gpio0 22 (${activeMode} | ${pullMode})>`,
-          `<&gpio0 24 (${activeMode} | ${pullMode})>`,
-          `<&gpio0 9  (${activeMode} | ${pullMode})>`,
-          `<&gpio0 10 (${activeMode} | ${pullMode})>`,
-          `<&gpio1 13 (${activeMode} | ${pullMode})>`,
-          `<&gpio1 15 (${activeMode} | ${pullMode})>`,
-        ],
-        colGpios: [
-          `<&shifter 0 ${activeMode}>`,
-          `<&shifter 1 ${activeMode}>`,
-          `<&shifter 2 ${activeMode}>`,
-          `<&shifter 3 ${activeMode}>`,
-          `<&shifter 4 ${activeMode}>`,
-          `<&shifter 5 ${activeMode}>`,
-          `<&shifter 6 ${activeMode}>`,
-        ],
+        rowGpios,
+        colGpios,
       },
       ...mapObjToObj(encodersWithLength, (encoders, side) => ({
         [`${side}_encoder: encoder_${side}`]: {
           compatible: 'alps,ec11',
-          aGpios: '<&gpio0 29 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>',
-          bGpios: '<&gpio0 31 (GPIO_ACTIVE_HIGH | GPIO_PULL_UP)>',
+          aGpios: gpioRef(profile.encoderA, '(GPIO_ACTIVE_HIGH | GPIO_PULL_UP)'),
+          bGpios: gpioRef(profile.encoderB, '(GPIO_ACTIVE_HIGH | GPIO_PULL_UP)'),
           steps: 80,
           status: 'disabled',
         },
@@ -426,18 +546,7 @@ function generateDTSI(config: FullGeometry, matrix: Matrix, options: ZMKOptions)
         }
         : {}),
     },
-    ...(!options.underGlowAtStart
-      ? {
-        [raw()]: '// Hack to force-drive the LED power pin high, ensuring LED power is off. Ext power is also disabled in the conf file.',
-        '&gpio0': {
-          'ext_power_hog: ext_power_hog': {
-            'gpio-hog': true,
-            'gpios': ['<2 GPIO_ACTIVE_LOW>'],
-            'output-high': true,
-          },
-        },
-      }
-      : {}),
+    ...extPowerBlock,
   })
 }
 
@@ -517,7 +626,7 @@ function generateOverlay(config: FullGeometry, matrix: Matrix, options: ZMKOptio
   })
 }
 
-const BOARD_OVERLAY = `#include <dt-bindings/led/led.h>
+const BOARD_OVERLAY_NRF52 = `#include <dt-bindings/led/led.h>
 
 &pinctrl {
     spi3_default: spi3_default {
@@ -587,6 +696,73 @@ vik_i2c: &i2c0 {};
 vik_spi: &spi1 {};
 `
 
+// Phase 1 wired board overlay. Sets up the UART used for the wired-split
+// transport (GP0/GP1 — the "Link" USB-C port pair on the Lemon Wired), the
+// VIK SPI/I2C buses, and the VIK connector pin map. RGB underglow is not
+// configured here yet: Zephyr 3.5 in the ZMK fork lacks an in-tree PIO
+// ws2812 driver, so the .conf file forces underglow off for this MCU.
+const BOARD_OVERLAY_RP2040 = `&pinctrl {
+    uart0_default: uart0_default {
+        group1 {
+            pinmux = <UART0_TX_P0>;
+        };
+        group2 {
+            pinmux = <UART0_RX_P1>;
+            input-enable;
+        };
+    };
+};
+
+&uart0 {
+    status = "okay";
+    current-speed = <115200>;
+    pinctrl-0 = <&uart0_default>;
+    pinctrl-names = "default";
+};
+
+&spi1 {
+    status = "okay";
+    clock-frequency = <DT_FREQ_M(4)>;
+};
+
+&i2c1 {
+    status = "okay";
+    clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+/ {
+    wired_split: wired_split {
+        compatible = "zmk,wired-split";
+        device = <&uart0>;
+    };
+
+    vik_conn: vik_connector {
+        compatible = "sadekbaroudi,vik-connector";
+        #gpio-cells = <2>;
+        gpio-map-mask = <0xffffffff 0xffffffc0>;
+        gpio-map-pass-thru = <0 0x3f>;
+        gpio-map
+          = <0 0 &gpio0 18 0>   /* vik SDA */
+          , <1 0 &gpio0 19 0>   /* vik SCL */
+          , <2 0 &gpio0  2 0>   /* vik RGB Data */
+          , <3 0 &gpio0 26 0>   /* vik AD_1 */
+          , <4 0 &gpio0 15 0>   /* vik MOSI */
+          , <5 0 &gpio0 27 0>   /* vik AD_2 */
+          , <6 0 &gpio0 13 0>   /* vik CS */
+          , <7 0 &gpio0 12 0>   /* vik MISO */
+          , <8 0 &gpio0 14 0>   /* vik SCLK */
+          ;
+    };
+};
+
+vik_i2c: &i2c1 {};
+vik_spi: &spi1 {};
+`
+
+function boardOverlay(options: ZMKOptions) {
+  return options.microcontroller === 'lemon-wired' ? BOARD_OVERLAY_RP2040 : BOARD_OVERLAY_NRF52
+}
+
 export function downloadZMKCode(config: FullGeometry, matrix: Matrix, options: ZMKOptions) {
   const { folderName } = options
   if (!folderName || folderName == '.') {
@@ -599,9 +775,9 @@ export function downloadZMKCode(config: FullGeometry, matrix: Matrix, options: Z
       'build.yaml': strToU8(generateBuildYaml(config, options)),
       'zephyr/module.yml': strToU8(generateModuleYaml()),
       'config/deps.yml': strToU8(generateDepsYaml()),
-      'config/west.yml': strToU8(generateWestYaml()),
+      'config/west.yml': strToU8(generateWestYaml(options)),
       [`boards/shields/${folderName}`]: {
-        [`boards/${boardName(options)}.overlay`]: strToU8(BOARD_OVERLAY),
+        [`boards/${boardName(options)}.overlay`]: strToU8(boardOverlay(options)),
         'Kconfig.defconfig': strToU8(generateDefconfig(config, options)),
         'Kconfig.shield': strToU8(generateShield(config, options)),
         [folderName + '.dtsi']: strToU8(generateDTSI(config, matrix, options)),

--- a/src/routes/beta/lib/firmware/zmk.ts
+++ b/src/routes/beta/lib/firmware/zmk.ts
@@ -122,7 +122,7 @@ const SPECIALS = [
 ]
 
 /** Return the ZMK keycode for a letter */
-function keycode(code: string | undefined) {
+export function keycode(code: string | undefined) {
   const c = code?.toLowerCase()
 
   if (!c || !code) return '&kp SPACE'

--- a/src/routes/beta/lib/firmware/zmk.ts
+++ b/src/routes/beta/lib/firmware/zmk.ts
@@ -30,7 +30,11 @@ export interface ZMKOptions {
   underGlowAtStart: boolean
   enableConsole: boolean
   enableStudio: boolean
+  microcontroller: 'lemon-wireless' | 'lemon-wired'
   wirelessVersion: 'v0.3' | 'v0.4'
+  wiredVersion?: 'v0.4' | 'v0.5'
+  splitTransport?: 'uart' | 'pio-usb'
+  linkPort?: 'pio' | 'native'
 }
 
 export function validateConfig(options: ZMKOptions) {

--- a/src/routes/beta/lib/firmware/zmk.ts
+++ b/src/routes/beta/lib/firmware/zmk.ts
@@ -8,6 +8,18 @@ import { dtsFile, encoderKeys, fullLayout, logicalKeys, type Matrix, raw, yamlFi
 
 const RE_PID_VID = /^0x[0-9A-Fa-f]{4}$/
 
+export const Microcontroller = {
+  LemonWireless: 'lemon-wireless',
+  LemonWired: 'lemon-wired',
+} as const
+export type Microcontroller = typeof Microcontroller[keyof typeof Microcontroller]
+
+export const SplitTransport = {
+  Uart: 'uart',
+  PioUsb: 'pio-usb',
+} as const
+export type SplitTransport = typeof SplitTransport[keyof typeof SplitTransport]
+
 interface ZMKPeripherals {
   pmw3610: boolean
   cirque: boolean
@@ -30,10 +42,10 @@ export interface ZMKOptions {
   underGlowAtStart: boolean
   enableConsole: boolean
   enableStudio: boolean
-  microcontroller: 'lemon-wireless' | 'lemon-wired'
+  microcontroller: Microcontroller
   wirelessVersion: 'v0.3' | 'v0.4'
   wiredVersion?: 'v0.4' | 'v0.5'
-  splitTransport?: 'uart' | 'pio-usb'
+  splitTransport?: SplitTransport
   linkPort?: 'pio' | 'native'
 }
 
@@ -162,7 +174,7 @@ function generateKeycodes(config: FullGeometry, matrix: Matrix, options: ZMKOpti
  *  v0.4 and v0.5 Wired share one Zephyr board — the only Phase-1 hardware
  *  diff (LED-relay polarity) is encoded in the per-shield ext_power_hog. */
 function boardName(options: ZMKOptions) {
-  if (options.microcontroller === 'lemon-wired') return 'cosmos_lemon_wired'
+  if (options.microcontroller === Microcontroller.LemonWired) return 'cosmos_lemon_wired'
   if (options.wirelessVersion == 'v0.4') return 'cosmos_lemon_wireless_v4'
   return 'cosmos_lemon_wireless'
 }
@@ -195,7 +207,7 @@ interface MCUProfile {
 }
 
 function mcuProfile(options: ZMKOptions): MCUProfile {
-  if (options.microcontroller === 'lemon-wired') {
+  if (options.microcontroller === Microcontroller.LemonWired) {
     const v05 = options.wiredVersion === 'v0.5'
     return {
       rows: [3, 4, 5, 6, 7, 8, 9].map((pin): GpioPin => ({ ctrl: '&gpio0', pin })),
@@ -349,9 +361,11 @@ function generateDepsYaml(): string {
 }
 
 function generateWestYaml(options: ZMKOptions): string {
-  // The Lemon Wired board lives on the Phase-1 branch of the Olson3R fork
-  // until that work merges upstream. Wireless continues to track rianadon/zmk.
-  const wired = options.microcontroller === 'lemon-wired'
+  // The Lemon Wired board + USB split transport live on the Olson3R fork
+  // until that work merges upstream. The fork's app/west.yml pulls in the
+  // Pico-PIO-USB module + Zephyr UHC/UDC glue transitively.
+  // Wireless continues to track rianadon/zmk.
+  const wired = options.microcontroller === Microcontroller.LemonWired
   return yamlFile({
     manifest: {
       remotes: [
@@ -361,7 +375,7 @@ function generateWestYaml(options: ZMKOptions): string {
       ],
       projects: [
         wired
-          ? { name: 'zmk', 'repo-path': 'rainadon-zmk', remote: 'Olson3R', revision: 'lemon-wired-zmk-phase1', import: 'app/west.yml' }
+          ? { name: 'zmk', 'repo-path': 'rainadon-zmk', remote: 'Olson3R', revision: 'main', import: 'app/west.yml' }
           : { name: 'zmk', remote: 'rianadon', revision: 'main', import: 'app/west.yml' },
       ],
       self: { path: 'config', import: 'deps.yml' },
@@ -372,6 +386,7 @@ function generateWestYaml(options: ZMKOptions): string {
 function generateDefconfig(config: FullGeometry, options: ZMKOptions) {
   const { folderName } = options
   const centralSide = options.centralSide.toUpperCase()
+  const usbSplit = options.microcontroller === Microcontroller.LemonWired && options.splitTransport !== SplitTransport.Uart
   return `
 if SHIELD_${folderName}_${centralSide}
 
@@ -387,7 +402,14 @@ if SHIELD_${folderName}_LEFT || SHIELD_${folderName}_RIGHT
 
 config ZMK_SPLIT
     default y
-
+${
+    usbSplit
+      ? `
+config ZMK_SPLIT_USB
+    default y
+`
+      : ''
+  }
 endif # SHIELD_${folderName}_LEFT || SHIELD_${folderName}_RIGHT
 `
 }
@@ -402,8 +424,10 @@ config SHIELD_${options.folderName}_RIGHT
 `
 }
 
-function generateConf(config: FullGeometry, options: ZMKOptions) {
-  const wired = options.microcontroller === 'lemon-wired'
+function generateConf(config: FullGeometry, options: ZMKOptions, side: keyof FullGeometry) {
+  const wired = options.microcontroller === Microcontroller.LemonWired
+  const usbSplit = wired && options.splitTransport !== SplitTransport.Uart
+  const isCentral = side === 'unibody' || side === options.centralSide
   // Phase 1: the wired path doesn't yet ship a working WS2812 driver
   // (RP2040 needs a PIO-based ws2812 binding the upstream Zephyr 3.5 doesn't
   // have). Force underglow off so the build completes; revisit once the wired
@@ -432,9 +456,24 @@ function generateConf(config: FullGeometry, options: ZMKOptions) {
         'CONFIG_PINCTRL=y',
         'CONFIG_GPIO=y',
         '',
-        '# Wired-split UART transport on GP0/GP1',
+        ...(usbSplit
+          ? [
+            '# Pico-PIO-USB split transport: legacy USB device stack on the',
+            '# native USB-C carries HID (central) / split bulk endpoints (peripheral);',
+            '# the central also runs Pico-PIO-USB as a UHC on the Link port.',
+            'CONFIG_USB_DEVICE_STACK=y',
+            'CONFIG_USB_CDC_ACM=y',
+            'CONFIG_SERIAL=y',
+            'CONFIG_UART_INTERRUPT_DRIVEN=y',
+            'CONFIG_UART_LINE_CTRL=y',
+            'CONFIG_USB_DEVICE_INITIALIZE_AT_BOOT=' + (isCentral ? 'y' : 'n'),
+            ...(isCentral ? ['CONFIG_ZMK_USB=y'] : []),
+          ]
+          : [
+            '# Wired-split UART transport on GP0/GP1',
+            'CONFIG_ZMK_SPLIT_WIRED=y',
+          ]),
         'CONFIG_ZMK_SPLIT=y',
-        'CONFIG_ZMK_SPLIT_WIRED=y',
       ]
       : []),
     '',
@@ -605,18 +644,86 @@ function generateOverlay(config: FullGeometry, matrix: Matrix, options: ZMKOptio
 
   const encoders = config[side] ? encoderKeys(config[side].c) : []
 
+  // Wired-split transport DT (Phase 2: USB over Link, or legacy: UART).
+  const wired = options.microcontroller === Microcontroller.LemonWired
+  const split = side !== 'unibody'
+  const usbSplit = wired && split && options.splitTransport !== SplitTransport.Uart
+  const uartSplit = wired && split && options.splitTransport === SplitTransport.Uart
+  const isCentral = split && side === options.centralSide
+  const wantConsole = !!options.enableConsole
+
+  // Central + USB split: disable uart0 (its pins are now PIO-USB D+/D-),
+  // bring up Pico-PIO-USB as a UHC on the Link port, expose it to ZMK as
+  // the split transport, and optionally surface a CDC ACM console on the
+  // native USB-C alongside HID.
+  const centralUsbBlock: Record<string, unknown> = usbSplit && isCentral
+    ? {
+      'pio_usb_host: pio_usb_host': {
+        compatible: 'raspberrypi,pio-usb-host',
+        pinDp: 0,
+        pinout: 'dpdm',
+        dataRate: 'full-speed',
+        status: 'okay',
+      },
+      'usb_split: usb_split': {
+        compatible: 'zmk,usb-split',
+        uhc: '<&pio_usb_host>',
+      },
+      ...(wantConsole
+        ? {
+          chosen: {
+            'zephyr,console': '&cdc_acm_uart0',
+            'zephyr,uart-mcumgr': '&cdc_acm_uart0',
+          },
+        }
+        : {}),
+    }
+    : {}
+
+  // Peripheral CDC ACM bulk pair — what the central's UHC enumerates and
+  // drives. The label `zsu_cdc_acm` is what ZMK's USB-split peripheral
+  // driver looks for via DT_CHOSEN/label lookup.
+  const peripheralCdcBlock = usbSplit && !isCentral
+    ? { 'zsu_cdc_acm: zsu_cdc_acm': { compatible: 'zephyr,cdc-acm-uart' } }
+    : {}
+
+  // Optional CDC ACM console on the central's native USB-C.
+  const centralConsoleCdc = usbSplit && isCentral && wantConsole
+    ? { 'cdc_acm_uart0: cdc_acm_uart0': { compatible: 'zephyr,cdc-acm-uart' } }
+    : {}
+
+  // Legacy UART split: GP0/GP1 carry a serial link between halves.
+  const wiredSplitNode = uartSplit
+    ? {
+      'wired_split: wired_split': {
+        compatible: 'zmk,wired-split',
+        device: '<&uart0>',
+      },
+    }
+    : {}
+
   return dtsFile({
     [raw()]: `#include "${options.folderName}.dtsi"`,
+    ...(usbSplit && isCentral
+      ? { '&uart0': { status: 'disabled' } }
+      : {}),
     '/': {
       'bootloader_key: bootloader_key': {
         compatible: 'zmk,boot-magic-key',
         keyPosition: bootloaderPosition,
         jumpToBootloader: true,
       },
+      ...centralUsbBlock,
+      ...wiredSplitNode,
     },
     '&default_transform': right && {
       colOffset: 7,
     },
+    ...(usbSplit && (Object.keys(centralConsoleCdc).length || Object.keys(peripheralCdcBlock).length)
+      ? {
+        '&zephyr_udc0': { ...centralConsoleCdc, ...peripheralCdcBlock },
+      }
+      : {}),
     ...(encoders.length
       ? {
         [`&${side}_encoder`]: {
@@ -697,18 +804,14 @@ vik_i2c: &i2c0 {};
 vik_spi: &spi1 {};
 `
 
-// Phase 1 wired board overlay. The cosmos_lemon_wired board (in the fork)
-// already enables &uart0/&spi1/&i2c1 with their pinctrl groups; this overlay
-// only adds the wired-split transport node and the VIK connector pin map.
+// Wired board overlay. The cosmos_lemon_wired board (in the fork) already
+// enables &uart0/&spi1/&i2c1 with their pinctrl groups; this overlay just
+// adds the VIK connector pin map. The split transport (UART or USB) lives
+// in the per-side overlay.
 // RGB underglow is not configured here yet: Zephyr 3.5 in the ZMK fork lacks
 // an in-tree PIO ws2812 driver, so the .conf file forces underglow off for
 // this MCU.
 const BOARD_OVERLAY_RP2040 = `/ {
-    wired_split: wired_split {
-        compatible = "zmk,wired-split";
-        device = <&uart0>;
-    };
-
     vik_conn: vik_connector {
         compatible = "sadekbaroudi,vik-connector";
         #gpio-cells = <2>;
@@ -733,7 +836,7 @@ vik_spi: &spi1 {};
 `
 
 function boardOverlay(options: ZMKOptions) {
-  return options.microcontroller === 'lemon-wired' ? BOARD_OVERLAY_RP2040 : BOARD_OVERLAY_NRF52
+  return options.microcontroller === Microcontroller.LemonWired ? BOARD_OVERLAY_RP2040 : BOARD_OVERLAY_NRF52
 }
 
 export function downloadZMKCode(config: FullGeometry, matrix: Matrix, options: ZMKOptions) {
@@ -760,13 +863,13 @@ export function downloadZMKCode(config: FullGeometry, matrix: Matrix, options: Z
         ...(config.unibody
           ? {
             [folderName + '.overlay']: strToU8(generateOverlay(config, matrix, options, 'unibody')),
-            [folderName + '.conf']: strToU8(generateConf(config, options)),
+            [folderName + '.conf']: strToU8(generateConf(config, options, 'unibody')),
           }
           : {
             [folderName + '_left.overlay']: strToU8(generateOverlay(config, matrix, options, 'left')),
             [folderName + '_right.overlay']: strToU8(generateOverlay(config, matrix, options, 'right')),
-            [folderName + '_left.conf']: strToU8(generateConf(config, options)),
-            [folderName + '_right.conf']: strToU8(generateConf(config, options)),
+            [folderName + '_left.conf']: strToU8(generateConf(config, options, 'left')),
+            [folderName + '_right.conf']: strToU8(generateConf(config, options, 'right')),
           }),
       },
     },

--- a/src/routes/beta/lib/firmware/zmk.ts
+++ b/src/routes/beta/lib/firmware/zmk.ts
@@ -157,11 +157,12 @@ function generateKeycodes(config: FullGeometry, matrix: Matrix, options: ZMKOpti
 
 /** Returns the Zephyr board name used for the given microcontroller selection.
  *  The Lemon Wireless board ships in `rianadon/zmk`; the Lemon Wired board
- *  ships in the Phase-1 fork branch wired up by generateWestYaml. */
+ *  ships in the Phase-1 fork branch wired up by generateWestYaml.
+ *
+ *  v0.4 and v0.5 Wired share one Zephyr board — the only Phase-1 hardware
+ *  diff (LED-relay polarity) is encoded in the per-shield ext_power_hog. */
 function boardName(options: ZMKOptions) {
-  if (options.microcontroller === 'lemon-wired') {
-    return options.wiredVersion === 'v0.5' ? 'cosmos_lemon_wired_v5' : 'cosmos_lemon_wired'
-  }
+  if (options.microcontroller === 'lemon-wired') return 'cosmos_lemon_wired'
   if (options.wirelessVersion == 'v0.4') return 'cosmos_lemon_wireless_v4'
   return 'cosmos_lemon_wireless'
 }
@@ -696,41 +697,13 @@ vik_i2c: &i2c0 {};
 vik_spi: &spi1 {};
 `
 
-// Phase 1 wired board overlay. Sets up the UART used for the wired-split
-// transport (GP0/GP1 — the "Link" USB-C port pair on the Lemon Wired), the
-// VIK SPI/I2C buses, and the VIK connector pin map. RGB underglow is not
-// configured here yet: Zephyr 3.5 in the ZMK fork lacks an in-tree PIO
-// ws2812 driver, so the .conf file forces underglow off for this MCU.
-const BOARD_OVERLAY_RP2040 = `&pinctrl {
-    uart0_default: uart0_default {
-        group1 {
-            pinmux = <UART0_TX_P0>;
-        };
-        group2 {
-            pinmux = <UART0_RX_P1>;
-            input-enable;
-        };
-    };
-};
-
-&uart0 {
-    status = "okay";
-    current-speed = <115200>;
-    pinctrl-0 = <&uart0_default>;
-    pinctrl-names = "default";
-};
-
-&spi1 {
-    status = "okay";
-    clock-frequency = <DT_FREQ_M(4)>;
-};
-
-&i2c1 {
-    status = "okay";
-    clock-frequency = <I2C_BITRATE_FAST>;
-};
-
-/ {
+// Phase 1 wired board overlay. The cosmos_lemon_wired board (in the fork)
+// already enables &uart0/&spi1/&i2c1 with their pinctrl groups; this overlay
+// only adds the wired-split transport node and the VIK connector pin map.
+// RGB underglow is not configured here yet: Zephyr 3.5 in the ZMK fork lacks
+// an in-tree PIO ws2812 driver, so the .conf file forces underglow off for
+// this MCU.
+const BOARD_OVERLAY_RP2040 = `/ {
     wired_split: wired_split {
         compatible = "zmk,wired-split";
         device = <&uart0>;

--- a/src/routes/beta/lib/viewers/Viewer3D.svelte
+++ b/src/routes/beta/lib/viewers/Viewer3D.svelte
@@ -42,7 +42,7 @@
   import { componentBoxes, componentGeometry } from '$lib/worker/geometry'
   import * as mdi from '@mdi/js'
   import Icon from '$lib/presentation/Icon.svelte'
-  import { DEFAULT_LAYOUT, flipLetter } from '$lib/layouts'
+  import { flipLetter } from '$lib/layouts'
   import {
     diff,
     filterObj,
@@ -61,6 +61,7 @@
   import Gizmo from '$lib/3d/ThrelteGizmo.svelte'
   import NewViewer from './Viewer.svelte'
   import {
+    detectLayout,
     indexOfKey,
     nthKey,
     nthPartType,
@@ -688,20 +689,20 @@
   // what's drawn rather than the right-side source-of-truth letter.
   $: needsLetterFlip =
     $clickedVisualSide === 'left' && clusterIsClicked != null && clusterIsClicked.side === 'right'
+  // Re-derive the layout from the kbd's own labels — the layout dropdown is
+  // a function of the keys, so the flip target follows the keys too.
+  $: detectedFlipLayout = $protoConfig ? detectLayout($protoConfig) : undefined
   $: displayedLetter = keyIsClicked
-    ? needsLetterFlip
-      ? flipLetter(keyIsClicked.profile.letter, $protoConfig?.layout ?? DEFAULT_LAYOUT) ??
-        keyIsClicked.profile.letter ??
-        ''
+    ? needsLetterFlip && detectedFlipLayout
+      ? flipLetter(keyIsClicked.profile.letter, detectedFlipLayout) ?? keyIsClicked.profile.letter ?? ''
       : keyIsClicked.profile.letter ?? ''
     : ''
 
   function setLetter(e: Event) {
     if (!keyIsClicked) return
     const typed = (e.target as HTMLInputElement).value
-    const stored = needsLetterFlip
-      ? flipLetter(typed, $protoConfig?.layout ?? DEFAULT_LAYOUT) ?? typed
-      : typed
+    const stored =
+      needsLetterFlip && detectedFlipLayout ? flipLetter(typed, detectedFlipLayout) ?? typed : typed
     protoConfig.update((p) => {
       keyIsClicked.profile.letter = stored
       return p

--- a/src/routes/beta/lib/viewers/Viewer3D.svelte
+++ b/src/routes/beta/lib/viewers/Viewer3D.svelte
@@ -16,6 +16,7 @@
     protoConfig,
     transformMode,
     clickedKey,
+    clickedVisualSide,
     selectMode,
     tempConfig,
     hoveredKey,
@@ -41,6 +42,7 @@
   import { componentBoxes, componentGeometry } from '$lib/worker/geometry'
   import * as mdi from '@mdi/js'
   import Icon from '$lib/presentation/Icon.svelte'
+  import { DEFAULT_LAYOUT, flipLetter } from '$lib/layouts'
   import {
     diff,
     filterObj,
@@ -678,10 +680,30 @@
       $protoConfig.wristRestPosition = encodeTuple(wrOrigin.map((w) => Math.round(w * 10)))
   }
 
+  // In mirror form (storage has only the right cluster, the left side is
+  // synthesized via mirrorCluster + flipLetter at render time), clicking a
+  // visually-left key resolves to the same right-cluster key as clicking the
+  // right counterpart. The Letter input then needs to flip the storage value
+  // through the layout's flipMap on read AND write so the user sees and types
+  // what's drawn rather than the right-side source-of-truth letter.
+  $: needsLetterFlip =
+    $clickedVisualSide === 'left' && clusterIsClicked != null && clusterIsClicked.side === 'right'
+  $: displayedLetter = keyIsClicked
+    ? needsLetterFlip
+      ? flipLetter(keyIsClicked.profile.letter, $protoConfig?.layout ?? DEFAULT_LAYOUT) ??
+        keyIsClicked.profile.letter ??
+        ''
+      : keyIsClicked.profile.letter ?? ''
+    : ''
+
   function setLetter(e: Event) {
     if (!keyIsClicked) return
+    const typed = (e.target as HTMLInputElement).value
+    const stored = needsLetterFlip
+      ? flipLetter(typed, $protoConfig?.layout ?? DEFAULT_LAYOUT) ?? typed
+      : typed
     protoConfig.update((p) => {
-      keyIsClicked.profile.letter = (e.target as HTMLInputElement).value
+      keyIsClicked.profile.letter = stored
       return p
     })
   }
@@ -1084,7 +1106,7 @@
                     <Field small name="Letter" icon="letter">
                       {#if keyIsClicked}<input
                           class="s-input w-[5.4rem] mx-0 px-2"
-                          bind:value={keyIsClicked.profile.letter}
+                          value={displayedLetter}
                           on:change={updateProto}
                           on:input={setLetter}
                         />


### PR DESCRIPTION
## Summary

Generator support for ZMK firmware on the Cosmos Lemon Wired RP2040 board, with **Pico-PIO-USB** as the split transport (a USB-C cable between the two halves' Link ports). Companion to the [rianadon/zmk PR #1](https://github.com/rianadon/zmk/pull/1).

**Depends on:**
- [#87](https://github.com/rianadon/Cosmos-Keyboards/pull/87) — keyboard layout selector (foundational)
- [#88](https://github.com/rianadon/Cosmos-Keyboards/pull/88) — Miryoku keymap preset

This PR's diff currently includes those two stacks. Once #87 and #88 land, the diff will narrow to just the lemon-wired commits below.

## What's in this stack (lemon-wired only)

- New `lemon-wired` microcontroller path through `generateConf` / `generateOverlay` / `generateDefconfig` / `generateWestYaml` / `boardOverlay` in `src/routes/beta/lib/firmware/zmk.ts`.
- Per-side conf emit: central gets `CONFIG_USB_DEVICE_STACK` + `CONFIG_ZMK_USB` + an optional CDC ACM console; peripheral gets the device stack + a `zsu_cdc_acm` node under `zephyr_udc0` (the central's PIO-USB UHC enumerates and drives that bulk pair). Both halves disable `CONFIG_FLASH/NVS/SETTINGS` until the rainadon-zmk fork ships a working RP2040 flash driver.
- Per-side overlay emit: central disables `&uart0`, brings up `raspberrypi,pio-usb-host` on GP0, exposes `zmk,usb-split` over it, and adds `cdc_acm_uart0` for the console when enabled. Peripheral declares `zsu_cdc_acm` under `&zephyr_udc0`.
- `west.yml` points at `Olson3R/rainadon-zmk@main` (the fork carrying the cosmos_lemon_wired board + USB split transport); the Pico-PIO-USB module + `Olson3R/zephyr-module-pio-usb@v0.1.0` wrapper come in transitively from the fork's `app/west.yml`.
- Splits string-literal types `'lemon-wired' | 'lemon-wireless'` and `'uart' | 'pio-usb'` into `as const` enum-likes (`Microcontroller`, `SplitTransport`).
- UI: Pico-PIO-USB is the default split transport; UART is the legacy fallback.

## Test plan

- [ ] `npm run check` passes
- [ ] `make dev` — open `/beta`, design a 36-key Lemon Wired layout, choose ZMK firmware
- [ ] Pick "Pico-PIO-USB" transport (default), download the zip
- [ ] Generated `config/west.yml` references `Olson3R/rainadon-zmk@main`
- [ ] Generated central `.conf` has `CONFIG_USB_DEVICE_STACK=y` + `CONFIG_ZMK_USB=y` + `CONFIG_ZMK_SPLIT_USB=y` + `CONFIG_FLASH=n` + `CONFIG_USB_DEVICE_PRODUCT="<your name>"` + a `CONSOLE/LOG` block when console is enabled
- [ ] Generated peripheral `.conf` has the device stack but **no** `CONFIG_ZMK_USB`; product name has " (peripheral)" suffix
- [ ] Generated central overlay disables `&uart0` and adds `pio_usb_host` + `usb_split` + `cdc_acm_uart0` nodes
- [ ] Generated peripheral overlay adds `zsu_cdc_acm` under `&zephyr_udc0`
- [ ] `west init -l config/ && west update && west build` succeeds for both halves
- [ ] Pick "UART (legacy)" transport; generator emits `zmk,wired-split` per-side (regression check)
- [ ] Wired unibody (no split): generator emits no USB-split or UART-split configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)