### PR TITLE
Adjust the mx-pumpkin partBottom geometry to avoid bottom plate interference

### DIFF
--- a/src/lib/geometry/socketsParts.ts
+++ b/src/lib/geometry/socketsParts.ts
@@ -83,7 +83,8 @@ export const PART_INFO: Record<CuttleKey['type'], PartInfo> = {
     partOverride: MX_PART,
     singlePartForVariants: true,
     socketSize: () => [18, 18, 6.1] as PartSize,
-    partBottom: () => [box(18, 18, 6.1)],
+    // 9.5: Measured value. MX_BOTTOM(8.5) + 1mm for the switch socket thickness
+    partBottom: () => [box(18, 18, 6.1), box(14, 14, 9.5)],
     keycap: 'mx',
     extraBomItems: () => ({ 'pcb': { item: 'Pumpkin Flex PCB', icon: 'pcb', count: 1 / 42 } }),
     variants: {


### PR DESCRIPTION
Hi folks,

I built the model with the latest main branch and printed. Sadly, the lowest key's socket doesn't fit within the case (right side, row 0, column 3) .

I checked the code and add one geometry to adjust the height correctly, the value is by my measurement. I'm not 100% sure this is the way to fix the problem, please assume this as the issue rather than the PR.

In any case, thanks for this wonderful project, I'm enjoying building keyboard with Cosmos!

----
<img width="500" alt="IMG_4888" src="https://github.com/user-attachments/assets/72f67115-e75b-4277-a221-129f524b0b7d" />
<img width="500" alt="IMG_4889" src="https://github.com/user-attachments/assets/eaa91ae3-c642-4c52-bb73-efb680282d80" />


http://localhost:5173/beta#cm:CsUBChkSBRCAbyAnEgIgExICIAASADgUQICGisAHChYSBRCAYyAnEgIgExICIAASAxCwOzgAChsSBRCAVyAnEgIgExICIAASAxCwLzgTQIDwvAIKExIFEIBLICcSAiATEgIgABIAOCcKExIFEIA/ICcSAiATEgIgABIAODsKHBICICcSAiATEgYQoIAKIAASAhAwOChAgIaKwAcKHBICICcSAiATEgYQoIAKIAASAhAwODxAgIaKwAcYAEDohaCu8FVI3oyrwAEKlAEKFxITEMCAAkCAgJgCSMKZoJWQvAFQQzgIChgSFBDAgAJAgIDMAkjCmaCVkLwBUIYBUDoKFRIQEEBAgIAgSNCVgN2Q9QNQC1CeAgoUEhAQQECAgPgBSOaZ/KeQC1BXUH8KFRIQEEBAgICkA0jwmcS10DBQdFCVARgCIgoIvgEQvgEYACAAQMuLhKSQNEitkfzHwJMGCqEBChkSBRCAAyAnEgIgExICIAASADgTQICGisAHChMSBRCADyAnEgIgExICIAASADgAChgSBRCAGyAnEgIgExICIAASADgUQIDwvAIKExIFEIAnICcSAiATEgIgABIAOCgKExIFEIAzICcSAiATEgIgABIAODwKHBICICcSAiATEgYQoIAKIAASAhAwOCdAgIaKwAcYAUDnhaCu8FVI3oqruAEYjqAKIgYIxwEQvwFQAlhQcg8YqgEYABgAGAAYABgAGACCAQiCAYsBggGMAQ==