### PR TITLE
feat: Add no LED options to mx-hotswap socket

### DIFF
--- a/src/lib/3d/Keyboard.svelte
+++ b/src/lib/3d/Keyboard.svelte
@@ -77,7 +77,7 @@
 
   function shouldFlipSwitch(key: CuttleKey) {
     if (key.type.startsWith('mx'))
-      return key.variant && 'led' in key.variant && key.variant.led == 'North LED'
+      return key.variant && 'led' in key.variant && key.variant.led.startsWith('North')
     if (key.type.startsWith('choc'))
       return key.variant && 'led' in key.variant && key.variant.led == 'South LED'
   }

--- a/src/lib/geometry/socketsParts.ts
+++ b/src/lib/geometry/socketsParts.ts
@@ -158,7 +158,7 @@ export const PART_INFO: Record<CuttleKey['type'], PartInfo> = {
     keycap: 'mx',
     extraBomItems: () => ({ ...BOM_MX_HOTSWAP, ...BOM_DIODE }),
     variants: {
-      led: ['North LED', 'South LED'],
+      led: ['North LED', 'North No LED', 'South LED', 'South No LED'],
       hotswap: ['Kailh', 'Gateron', 'Outemu'],
     },
     encodeVariant: makeEncodeVariant('mx-hotswap', { hotswap: 2, led: 2 }),

--- a/src/model_gen/keyholes.cljs
+++ b/src/model_gen/keyholes.cljs
@@ -224,7 +224,8 @@
 (defn make-hotswap-holder [hotswap-y1
                            hotswap-cutout-1-y-offset
                            hotswap-y2
-                           hotswap-cutout-2-y-offset]
+                           hotswap-cutout-2-y-offset
+                           & [include-led-cutout?]]
   ;irregularly shaped hot swap holder
   ;    ____________
   ;  |  _|_______|    |  hotswap offset from out edge of holder with room to solder
@@ -235,7 +236,7 @@
   ;    |    |_|    |  space for LED under SMD or transparent switches
   ;
   ; can be described as having two sizes in the y dimension depending on the x coordinate
-  (let [
+  (let [include-led-cutout? (if (nil? include-led-cutout?) true include-led-cutout?)
         swap-x              holder-x
         swap-y              holder-y
 
@@ -345,31 +346,27 @@
         friction-hole-right (translate [ 5 0 0] friction-hole)
         friction-hole-left  (translate [-5 0 0] friction-hole)
         hotswap-shape
-            (difference
-                       ; (union
-                               swap-holder
-                               ; (debug diode-channel-wire))
-                        main-axis-hole
-                        plus-hole
-                        minus-hole
-                        friction-hole-left
-                        friction-hole-right
-                        (if hotswap-diode-cutout
-                             (union diode-cutout
-                                    diode-socket-hole-left
-                                    diode-channel-pin-left
-                                    ;; (mirror [1 0 0] diode-cutout)
-                                    ;; diode-socket-hole-right
-                                    ;; diode-channel-pin-right
-                             )
-                        )
-
-                        hotswap-cutout-1
-                        hotswap-cutout-2
-                        hotswap-cutout-3
-                        hotswap-cutout-4
-
-                        hotswap-led-cutout)
+            (apply difference
+                   (concat [swap-holder
+                            main-axis-hole
+                            plus-hole
+                            minus-hole
+                            friction-hole-left
+                            friction-hole-right]
+                           (if hotswap-diode-cutout
+                                [(union diode-cutout
+                                        diode-socket-hole-left
+                                        diode-channel-pin-left
+                                        ;; (mirror [1 0 0] diode-cutout)
+                                        ;; diode-socket-hole-right
+                                        ;; diode-channel-pin-right
+                                 )]
+                                [])
+                           [hotswap-cutout-1
+                            hotswap-cutout-2
+                            hotswap-cutout-3
+                            hotswap-cutout-4]
+                           (if include-led-cutout? [hotswap-led-cutout] [])))
        ]
        (if north_facing
            (->> hotswap-shape
@@ -682,13 +679,15 @@
                    hotswap-y1
                    hotswap-cutout-1-y-offset
                    hotswap-y2
-                   hotswap-cutout-2-y-offset]
+                   hotswap-cutout-2-y-offset
+                   & [include-led-cutout?]]
   (binding [tk toolkit
             cylinder (. toolkit -cylinder)]
-    (make-hotswap-holder hotswap-y1
-                         hotswap-cutout-1-y-offset
-                         hotswap-y2
-                         hotswap-cutout-2-y-offset)))
+    (apply make-hotswap-holder hotswap-y1
+           hotswap-cutout-1-y-offset
+           hotswap-y2
+           hotswap-cutout-2-y-offset
+           (when (some? include-led-cutout?) [include-led-cutout?]))))
 
 (set! (. js/exports -singlePlate) (jsify single-plate))
 (set! (. js/exports -makeHotswapHolder) hotswaperoo)

--- a/src/model_gen/keyholes.ts
+++ b/src/model_gen/keyholes.ts
@@ -47,8 +47,6 @@ async function generateHotswapKey(name: string, ...options: any[]) {
   const extrude = basicFaceExtrusion(moveFace, new Vector([0, 0, -1.15]))
 
   const gen = await import('../../target/gen-keyholes.cjs')
-  const inst = gen.makeHotswapHolder(modeling, ...options)
-  const bottom = modeling.compute(inst).translateZ(-5)
 
   // Cylinders to provide a smooth transition to the diode hole
   const c1Top = drawCircle(0.45).translate(6.55, -1.5).sketchOnPlane('XY', -3.5) as Sketch
@@ -61,13 +59,27 @@ async function generateHotswapKey(name: string, ...options: any[]) {
   const lastDash = name.lastIndexOf('-')
   const [baseName, variantName] = [name.substring(0, lastDash), name.substring(lastDash + 1)]
 
-  const modelNorth = top.fuse(extrude).fuse(bottom).cut(c1).cut(c2)
+  const assemble = (includeLedCutout: boolean) => {
+    const inst = gen.makeHotswapHolder(modeling, ...options, includeLedCutout)
+    const bottom = modeling.compute(inst).translateZ(-5)
+    return top.fuse(extrude).fuse(bottom).cut(c1).cut(c2)
+  }
+
+  const modelNorth = assemble(true)
   const fileNorth = modeling.serialize(name, modelNorth)
   await writeFile(`target/key-${baseName}-north-led-${variantName}.step`, fileNorth)
+
+  const modelNoLedNorth = assemble(false)
+  const fileNoLedNorth = modeling.serialize(name, modelNoLedNorth)
+  await writeFile(`target/key-${baseName}-north-no-led-${variantName}.step`, fileNoLedNorth)
 
   const modelSouth = modelNorth.rotate(180, [0, 0, 1])
   const fileSouth = modeling.serialize(name, modelSouth)
   await writeFile(`target/key-${baseName}-south-led-${variantName}.step`, fileSouth)
+
+  const modelNoLedSouth = modelNoLedNorth.rotate(180, [0, 0, 1])
+  const fileNoLedSouth = modeling.serialize(name, modelNoLedSouth)
+  await writeFile(`target/key-${baseName}-south-no-led-${variantName}.step`, fileNoLedSouth)
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- Adds `North No LED` and `South No LED` options to the `mx-hotswap` socket

<img width="817" height="2442" alt="screencapture-localhost-5173-parts-2026-06-24-13_19_56" src="https://github.com/user-attachments/assets/35f87401-1ef6-4ba5-b042-e1e5e26c65bb" />



## Test plan
- [ ] `npm run check` passes (verified locally).
- [ ] In `/parts`, see the `North No LED` and `South No LED` options under `MX + 3DP Hotswap`
