### PR TITLE
Fix language selection bugs in firmware autogen

### DIFF
--- a/src/routes/beta/lib/editor/PeaConfig.svelte
+++ b/src/routes/beta/lib/editor/PeaConfig.svelte
@@ -71,7 +71,7 @@
       : []
 
   $: guessedLangauge = LAYOUTS[detectLayout(toFullCosmosConfig(config))].languages[0].name
-  $: osLanguage = guessedLangauge
+  $: if (!osLanguage) osLanguage = guessedLangauge
 
   const languageGroups = partitionLanguages(window?.navigator.languages)
   const languageOptions = {
@@ -113,7 +113,7 @@
   help="This is the keyboard layout you have installed on your operating system. It can be different than your Cosmos keyboard."
 >
   <SelectThingy
-    value={guessedLangauge}
+    value={osLanguage}
     on:change={(ev) => (osLanguage = ev.detail)}
     options={languageOptions}
     component={SelectLanguageInner}

--- a/src/routes/beta/lib/firmware/qmk.ts
+++ b/src/routes/beta/lib/firmware/qmk.ts
@@ -362,10 +362,12 @@ const EXTRAKEY_REQUIRED = new Set([
 
 /** The QMK locale id (keymap_<id>.h basename) to use for a language, or undefined for US/none. */
 function qmkLocale(language: Language | undefined): string | undefined {
-  const id = language?.qmk || language?.qmkCharset
-  if (!id) return undefined
-  const map = QMK_CODES[id]
-  return map && Object.keys(map).length ? id : undefined
+  for (const id of [language?.qmk, language?.qmkCharset]) {
+    if (!id) continue
+    const map = QMK_CODES[id]
+    if (map && Object.keys(map).length) return id
+  }
+  return undefined
 }
 
 /**
@@ -385,7 +387,7 @@ function resolveKeycode(code: string | undefined, language?: Language): { code: 
     const map = QMK_CODES[locale]
     const hit = map[code] ?? map[c] // exact case first, then lowercased
     if (hit) return { code: hit, unmapped: false }
-    if (isQWERTYKey(c)) return { code: 'KP_SPACE', unmapped: true }
+    if (isQWERTYKey(c)) return { code: 'KC_SPACE', unmapped: true }
   }
 
   if (/^[a-z]$/.test(c)) return { code: 'KC_' + c.toUpperCase(), unmapped: false }

--- a/src/routes/beta/lib/firmware/zmk.ts
+++ b/src/routes/beta/lib/firmware/zmk.ts
@@ -126,10 +126,12 @@ const SPECIALS = [
 
 /** The ZMK locale id (keys_<id>.h basename) to use for a language, or undefined for US/none. */
 function zmkLocale(language: Language | undefined): string | undefined {
-  const id = language?.zmk || language?.zmkCharset
-  if (!id) return undefined
-  const map = ZMK_CODES[id]
-  return map && Object.keys(map).length ? id : undefined
+  for (const id of [language?.zmk, language?.zmkCharset]) {
+    if (!id) continue
+    const map = ZMK_CODES[id]
+    if (map && Object.keys(map).length) return id
+  }
+  return undefined
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up bug fixes for #87, found in a post-merge audit of the language-aware QMK/ZMK keycode generation:

- **`qmk.ts`** — emit `KC_SPACE` (not `KP_SPACE`) for unmapped QWERTY keys under a non-US locale. `KP_SPACE` is not a valid QMK identifier and would have produced uncompilable `keymap.c` whenever the active locale map omitted any QWERTY-position key the user assigned to a keycap.
- **`qmk.ts` / `zmk.ts`** — make `qmkCharset` / `zmkCharset` actually serve as a fallback. The previous `language?.qmk || language?.qmkCharset` short-circuited on the first truthy value, so a language with a primary id that wasn't in `QMK_CODES`/`ZMK_CODES` would skip the charset entirely. The for-loop walks both ids and returns the first one with a populated map.
- **`PeaConfig.svelte`** — bind the OS layout dropdown to `osLanguage` instead of the auto-guess (`guessedLangauge`), and only seed `osLanguage` from the guess while it's still unset. Before, the dropdown showed the guess regardless of what the user picked, and the reactive `$: osLanguage = guessedLangauge` reset the user's selection on every config edit.

## Test plan

- [x] `bun test src/routes/beta/lib/firmware/qmk.test.ts src/routes/beta/lib/firmware/zmk.test.ts` — 8/8 pass
- [x] `bunx svelte-check` — no new errors in touched files
- [ ] In the browser: pick a non-US OS Keyboard Layout, edit an unrelated config field, confirm the selection survives
- [ ] In the browser: download QMK code for a layout missing some QWERTY keys, confirm `keymap.c` compiles (no stray `KP_SPACE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)